### PR TITLE
Allow passing a string as argument to the Lua startup file

### DIFF
--- a/src/include/parameters.h
+++ b/src/include/parameters.h
@@ -46,6 +46,7 @@ public:
 	std::string applicationName;
 	std::string luaStartFilename;
 	std::string luaEditorStartFilename;
+	std::string luaScriptArguments;
 	std::string LocalPlayerName;        /// Name of local player
 private:
 	std::string userDirectory;          /// Directory containing user settings and data

--- a/src/include/script.h
+++ b/src/include/script.h
@@ -310,6 +310,7 @@ extern bool LuaToBoolean(lua_State *l, int index, int subIndex);
 
 extern void LuaGarbageCollect();  /// Perform garbage collection
 extern void InitLua();                /// Initialise Lua
+extern void LoadCcl(const std::string &filename, const std::string &luaArgStr);  /// Load ccl config file
 extern void LoadCcl(const std::string &filename);  /// Load ccl config file
 extern void SavePreferences();        /// Save user preferences
 extern int CclCommand(const std::string &command, bool exitOnError = true);

--- a/src/include/script.h
+++ b/src/include/script.h
@@ -68,7 +68,7 @@ enum {
 
 extern lua_State *Lua;
 
-extern int LuaLoadFile(const std::string &file);
+extern int LuaLoadFile(const std::string &file, const std::string &strArg = "");
 extern int LuaCall(int narg, int clear, bool exitOnError = true);
 
 #define LuaError(l, args) \
@@ -310,8 +310,7 @@ extern bool LuaToBoolean(lua_State *l, int index, int subIndex);
 
 extern void LuaGarbageCollect();  /// Perform garbage collection
 extern void InitLua();                /// Initialise Lua
-extern void LoadCcl(const std::string &filename, const std::string &luaArgStr);  /// Load ccl config file
-extern void LoadCcl(const std::string &filename);  /// Load ccl config file
+extern void LoadCcl(const std::string &filename, const std::string &luaArgStr = "");  /// Load ccl config file
 extern void SavePreferences();        /// Save user preferences
 extern int CclCommand(const std::string &command, bool exitOnError = true);
 

--- a/src/network/netconnect.cpp
+++ b/src/network/netconnect.cpp
@@ -1507,7 +1507,7 @@ void NetworkServerStartGame()
 		}
 	}
 
-#if 0
+#ifdef DEBUG
 	printf("INITIAL ServerSetupState:\n");
 	for (int i = 0; i < PlayerMax - 1; ++i) {
 		printf("%02d: CO: %d   Race: %d   Host: ", i, ServerSetupState.CompOpt[i], ServerSetupState.Race[i]);

--- a/src/stratagus/iolib.cpp
+++ b/src/stratagus/iolib.cpp
@@ -615,6 +615,16 @@ static void LibraryFileName(const char *file, char(&buffer)[PATH_MAX])
 		return;
 	}
 
+	// Support for scripts in default scripts dir.
+	sprintf(buffer, "scripts/%s", file);
+	if (FindFileWithExtension(buffer)) {
+		return;
+	}
+	sprintf(buffer, "%s/scripts/%s", StratagusLibPath.c_str(), file);
+	if (FindFileWithExtension(buffer)) {
+		return;
+	}
+
 	DebugPrint("File `%s' not found\n" _C_ file);
 	strcpy_s(buffer, PATH_MAX, file);
 }

--- a/src/stratagus/script.cpp
+++ b/src/stratagus/script.cpp
@@ -233,18 +233,6 @@ int LuaLoadFile(const std::string &file, const std::string &strArg)
 }
 
 /**
-**  Load a file and execute it
-**
-**  @param file  File to load and execute
-**
-**  @return      0 for success, else exit.
-*/
-int LuaLoadFile(const std::string &file)
-{
-	return LuaLoadFile(file, std::string());
-}
-
-/**
 **  Save preferences
 **
 **  @param l  Lua state.
@@ -2417,11 +2405,6 @@ void LoadCcl(const std::string &filename, const std::string &luaArgStr)
 	LuaLoadFile(name, luaArgStr);
 	CclInConfigFile = 0;
 	LuaGarbageCollect();
-}
-
-void LoadCcl(const std::string &filename)
-{
-	LoadCcl(filename, std::string());
 }
 
 void ScriptRegister()

--- a/src/stratagus/script.cpp
+++ b/src/stratagus/script.cpp
@@ -205,10 +205,11 @@ static bool GetFileContent(const std::string &file, std::string &content)
 **  Load a file and execute it
 **
 **  @param file  File to load and execute
+**  @param nargs Number of arguments that caller has put on the stack
 **
 **  @return      0 for success, else exit.
 */
-int LuaLoadFile(const std::string &file)
+int LuaLoadFile(const std::string &file, const std::string &strArg)
 {
 	DebugPrint("Loading '%s'\n" _C_ file.c_str());
 
@@ -219,11 +220,28 @@ int LuaLoadFile(const std::string &file)
 	const int status = luaL_loadbuffer(Lua, content.c_str(), content.size(), file.c_str());
 
 	if (!status) {
-		LuaCall(0, 1);
+		if (!strArg.empty()) {
+			lua_pushstring(Lua, strArg.c_str());
+			LuaCall(1, 1);
+		} else {
+			LuaCall(0, 1);
+		}
 	} else {
 		report(status, true);
 	}
 	return status;
+}
+
+/**
+**  Load a file and execute it
+**
+**  @param file  File to load and execute
+**
+**  @return      0 for success, else exit.
+*/
+int LuaLoadFile(const std::string &file)
+{
+	return LuaLoadFile(file, std::string());
 }
 
 /**
@@ -2385,7 +2403,7 @@ void SavePreferences()
 /**
 **  Load stratagus config file.
 */
-void LoadCcl(const std::string &filename)
+void LoadCcl(const std::string &filename, const std::string &luaArgStr)
 {
 	//  Load and evaluate configuration file
 	CclInConfigFile = 1;
@@ -2396,11 +2414,15 @@ void LoadCcl(const std::string &filename)
 	}
 
 	ShowLoadProgress(_("Script %s\n"), name.c_str());
-	LuaLoadFile(name);
+	LuaLoadFile(name, luaArgStr);
 	CclInConfigFile = 0;
 	LuaGarbageCollect();
 }
 
+void LoadCcl(const std::string &filename)
+{
+	LoadCcl(filename, std::string());
+}
 
 void ScriptRegister()
 {

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -460,6 +460,7 @@ static void Usage()
 		"\t-e\t\tStart editor (instead of game)\n"
 		"\t-E file.lua\tEditor configuration start file (default editor.lua)\n"
 		"\t-F\t\tFull screen video mode\n"
+		"\t-G \"[options]\"\tGame options (passed to game scripts)\n"
 		"\t-h\t\tHelp shows this page\n"
 		"\t-i\t\tEnables unit info dumping into log (for debugging)\n"
 		"\t-I addr\t\tNetwork address to use\n"
@@ -533,7 +534,7 @@ static void RedirectOutput()
 void ParseCommandLine(int argc, char **argv, Parameters &parameters)
 {
 	for (;;) {
-		switch (getopt(argc, argv, "ac:d:D:eE:FhiI:lN:oOP:ps:S:u:v:Wx:Z?")) {
+		switch (getopt(argc, argv, "ac:d:D:eE:FG:hiI:lN:oOP:ps:S:u:v:Wx:Z?-")) {
 			case 'a':
 				EnableAssert = true;
 				continue;
@@ -560,6 +561,9 @@ void ParseCommandLine(int argc, char **argv, Parameters &parameters)
 			case 'F':
 				VideoForceFullScreen = 1;
 				Video.FullScreen = 1;
+				continue;
+			case 'G':
+				parameters.luaScriptArguments = optarg;
 				continue;
 			case 'i':
 				EnableUnitDebug = true;
@@ -661,7 +665,7 @@ void ParseCommandLine(int argc, char **argv, Parameters &parameters)
 	}
 
 	if (argc - optind > 1) {
-		fprintf(stderr, "too many files\n");
+		fprintf(stderr, "too many map files. if you meant to pass game arguments, these go after '--'\n");
 		Usage();
 		ExitFatal(-1);
 	}
@@ -754,7 +758,7 @@ int stratagusMain(int argc, char **argv)
 	// Initialise AI module
 	InitAiModule();
 
-	LoadCcl(parameters.luaStartFilename);
+	LoadCcl(parameters.luaStartFilename, parameters.luaScriptArguments);
 
 	PrintHeader();
 	PrintLicense();

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -540,6 +540,10 @@ void ParseCommandLine(int argc, char **argv, Parameters &parameters)
 				continue;
 			case 'c':
 				parameters.luaStartFilename = optarg;
+				if (strlen(optarg) > 4 &&
+				    !(strstr(optarg, ".lua") == optarg + strlen(optarg) - 4)) {
+					parameters.luaStartFilename += ".lua";
+				}
 				continue;
 			case 'd': {
 				StratagusLibPath = optarg;


### PR DESCRIPTION
This is related to https://github.com/Wargus/wargus/issues/132, as this allows us to handle commandline arguments in lua scripts. This commit also makes the script searching a little more clever, so we could conceivably have lua scripts in the user directory that then handle arguments and run the game.