### PR TITLE
For incomplete wall tilesets, keep the current directionality if the new direction is missing

### DIFF
--- a/src/include/tileset.h
+++ b/src/include/tileset.h
@@ -137,6 +137,8 @@ public:
 	unsigned getTopOneTreeTile() const { return topOneTreeTile; }
 	unsigned getMidOneTreeTile() const { return midOneTreeTile; }
 
+	unsigned getWallDirection(int tileIndex, bool human) const;
+
 	unsigned getHumanWallTileIndex(int dirFlag) const;
 	unsigned getOrcWallTileIndex(int dirFlag) const;
 	unsigned getHumanWallTileIndex_broken(int dirFlag) const;

--- a/src/map/map_wall.cpp
+++ b/src/map/map_wall.cpp
@@ -60,9 +60,9 @@
   For the connecting new walls -- all's fine.
 */
 
-static unsigned int getWallTile(const CTileset &tileset, bool humanWall, int dirFlag, int value)
+static unsigned int getWallTile(const CTileset &tileset, bool humanWall, int dirFlag, int value, unsigned int oldTile = 0)
 {
-	unsigned int tileIndex;
+	unsigned int tileIndex, newTile;
 	if (humanWall) {
 		if (value == 0) {
 			tileIndex = tileset.getHumanWallTileIndex_destroyed(dirFlag);
@@ -80,7 +80,13 @@ static unsigned int getWallTile(const CTileset &tileset, bool humanWall, int dir
 			tileIndex = tileset.getOrcWallTileIndex(dirFlag);
 		}
 	}
-	return tileset.tiles[tileIndex].tile;
+	newTile = tileset.tiles[tileIndex].tile;
+	if (!newTile && oldTile) {
+		unsigned int oldTileIndex = tileset.findTileIndexByTile(oldTile);
+		return getWallTile(tileset, humanWall, tileset.getWallDirection(oldTileIndex, humanWall), value);
+	} else {
+		return newTile;
+	}
 }
 
 
@@ -128,7 +134,7 @@ void MapFixSeenWallTile(const Vec2i &pos)
 	}
 	const bool human = tileset.isARaceWallTile(tile, true);
 	const int dirFlag = GetDirectionFromSurrounding(pos, human, true);
-	const int wallTile = getWallTile(tileset, human, dirFlag, mf.Value);
+	const int wallTile = getWallTile(tileset, human, dirFlag, mf.Value, tile);
 
 	if (mf.playerInfo.SeenTile != wallTile) { // Already there!
 		mf.playerInfo.SeenTile = wallTile;
@@ -172,7 +178,7 @@ void MapFixWallTile(const Vec2i &pos)
 	}
 	const bool human = tileset.isARaceWallTile(tile, true);
 	const int dirFlag = GetDirectionFromSurrounding(pos, human, false);
-	const unsigned int wallTile = getWallTile(tileset, human, dirFlag, mf.Value);
+	const unsigned int wallTile = getWallTile(tileset, human, dirFlag, mf.Value, tile);
 
 	if (mf.getGraphicTile() != wallTile) {
 		mf.setGraphicTile(wallTile);

--- a/src/map/tileset.cpp
+++ b/src/map/tileset.cpp
@@ -644,6 +644,16 @@ void CTileset::fillSolidTiles(std::vector<unsigned int> *solidTiles) const
 	}
 }
 
+unsigned CTileset::getWallDirection(int tileIndex, bool human) const
+{
+	int i;
+	tileIndex &= 0xff0; // only the base indices are in the tables
+	for (i = 0; i < 16; i++) {
+		if ((human && humanWallTable[i] == tileIndex) || orcWallTable[i] == tileIndex) {
+			return i;
+		}
+	}
+}
 unsigned CTileset::getHumanWallTileIndex(int dirFlag) const
 {
 	return humanWallTable[dirFlag];
@@ -667,18 +677,21 @@ static unsigned int NextSection(const CTileset &tileset, unsigned int tileIndex)
 unsigned CTileset::getHumanWallTileIndex_broken(int dirFlag) const
 {
 	unsigned tileIndex = humanWallTable[dirFlag];
+	if (!tiles[tileIndex].tile) return 0;
 	tileIndex = NextSection(*this, tileIndex);
 	return tileIndex;
 }
 unsigned CTileset::getOrcWallTileIndex_broken(int dirFlag) const
 {
 	unsigned tileIndex = orcWallTable[dirFlag];
+	if (!tiles[tileIndex].tile) return 0;
 	tileIndex = NextSection(*this, tileIndex);
 	return tileIndex;
 }
 unsigned CTileset::getHumanWallTileIndex_destroyed(int dirFlag) const
 {
 	unsigned tileIndex = humanWallTable[dirFlag];
+	if (!tiles[tileIndex].tile) return 0;
 	tileIndex = NextSection(*this, tileIndex);
 	tileIndex = NextSection(*this, tileIndex);
 	return tileIndex;
@@ -686,6 +699,7 @@ unsigned CTileset::getHumanWallTileIndex_destroyed(int dirFlag) const
 unsigned CTileset::getOrcWallTileIndex_destroyed(int dirFlag) const
 {
 	unsigned tileIndex = orcWallTable[dirFlag];
+	if (!tiles[tileIndex].tile) return 0;
 	tileIndex = NextSection(*this, tileIndex);
 	tileIndex = NextSection(*this, tileIndex);
 	return tileIndex;


### PR DESCRIPTION
I wpuld like to use this for war1gus, where dungeon doors are destructible like walls, but they dont have all the possible directions. @Andrettin, you have dungeons in Wyrmsun, too, do you think this looks ok, or might it break something?