### PR TITLE
Refactor target searching for splash missiles to make friendly fire configurable

### DIFF
--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -170,6 +170,7 @@ enum {
 	NORANDOMPLACING_INDEX,			/// Don't use random frame rotation
 	ORGANIC_INDEX,					/// Organic unit (used for death coil spell)
 	SIDEATTACK_INDEX,
+	NOFRIENDLYFIRE_INDEX,           /// Unit accepts friendly fire for splash attacks
 	NBARALREADYDEFINED
 };
 

--- a/src/unit/script_unittype.cpp
+++ b/src/unit/script_unittype.cpp
@@ -93,6 +93,7 @@ static const char WALL_KEY[] = "Wall";
 static const char NORANDOMPLACING_KEY[] = "NoRandomPlacing";
 static const char ORGANIC_KEY[] = "organic";
 static const char SIDEATTACK_KEY[] = "SideAttack";
+static const char NOFRIENDLYFIRE_KEY[] = "NoFriendlyFire";
 
 // names of the variable.
 static const char HITPOINTS_KEY[] = "HitPoints";
@@ -150,7 +151,7 @@ CUnitTypeVar::CBoolKeys::CBoolKeys()
 							   SHOREBUILDING_KEY, CANATTACK_KEY, BUILDEROUTSIDE_KEY,
 							   BUILDERLOST_KEY, CANHARVEST_KEY, HARVESTER_KEY, SELECTABLEBYRECTANGLE_KEY,
 							   ISNOTSELECTABLE_KEY, DECORATION_KEY, INDESTRUCTIBLE_KEY, TELEPORTER_KEY, SHIELDPIERCE_KEY,
-							   SAVECARGO_KEY, NONSOLID_KEY, WALL_KEY, NORANDOMPLACING_KEY, ORGANIC_KEY, SIDEATTACK_KEY
+							   SAVECARGO_KEY, NONSOLID_KEY, WALL_KEY, NORANDOMPLACING_KEY, ORGANIC_KEY, SIDEATTACK_KEY, NOFRIENDLYFIRE_KEY
 							  };
 
 	for (int i = 0; i < NBARALREADYDEFINED; ++i) {


### PR DESCRIPTION
Prompted by https://github.com/Wargus/war1gus/issues/63, I looked at the code for target finding when we have a missile with splash damage. In Warcraft 1, catapults simply will not fire if there is a chance it might hurt friendly units (even if they would survive). Stratagus seems to use a cost-weighing function that accepts friendly fire, and only slightly prefers to attack units that are not near friendly units if possible.

I refactored this code to be slightly more explicit, and I added a FriendlyFire flag (by default set to true) that determines if we want Warcraft 1 type behavior for a unit type. I don't want to merge this without some feedback, so that's why the pull request