### PR TITLE
Allow building over decorative buildings without HP

### DIFF
--- a/src/unit/unittype.cpp
+++ b/src/unit/unittype.cpp
@@ -661,7 +661,12 @@ void UpdateUnitStats(CUnitType &type, int reset)
 								MapFieldWaterAllowed |
 								MapFieldNoBuilding |
 								MapFieldUnpassable;
-			type.FieldFlags = MapFieldNoBuilding;
+			if (type.BoolFlag[DECORATION_INDEX].value && type.MapDefaultStat.Variables[HP_INDEX].Max == 0) {
+				// special case, a decoration with no HP can always be built over
+				type.FieldFlags = 0;
+			} else {
+				type.FieldFlags = MapFieldNoBuilding;
+			}
 		} else {
 			type.MovementMask = 0;
 			type.FieldFlags = 0;


### PR DESCRIPTION
This change is needed for War1gus. In War1gus, you should be able to build directly over roads. One way to do this would be to make them decorations but not buildings, but then you can built them on map tiles marked with `no-building`. This solution makes roads be buildings again, but since they do not have HP, they _can_ be built over. If there are no objections to this, I'll merge this later tonight.