### PR TITLE
Fixed FSF address

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>ChangeLog: Stratagus Version 2.3</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/doc/development.html
+++ b/doc/development.html
@@ -16,8 +16,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Development for Stratagus</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/faq.html
+++ b/doc/faq.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>FAQ for Stratagus</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/graphics/palette.html
+++ b/doc/graphics/palette.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Palette Documentation</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/graphics/tileset.html
+++ b/doc/graphics/tileset.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus tileset graphic format</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/index.html
+++ b/doc/index.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/install.html
+++ b/doc/install.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Installation</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/media.html
+++ b/doc/media.html
@@ -15,8 +15,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Media Documentation</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/doc/scripts/ai.html
+++ b/doc/scripts/ai.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Artificial Intelligence(AI)</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/config.html
+++ b/doc/scripts/config.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Config</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/game.html
+++ b/doc/scripts/game.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Icon</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/index.html
+++ b/doc/scripts/index.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Index</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/magic.html
+++ b/doc/scripts/magic.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Magic</title>
     <meta name="Author" content="cleonard@go.ro">

--- a/doc/scripts/mappresentation.html
+++ b/doc/scripts/mappresentation.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: PUD conversion</title>
 </head>

--- a/doc/scripts/mapsetup.html
+++ b/doc/scripts/mapsetup.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: PUD conversion</title>
 </head>

--- a/doc/scripts/research.html
+++ b/doc/scripts/research.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Icon</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/savegame.html
+++ b/doc/scripts/savegame.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Save Game Files</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/sound.html
+++ b/doc/scripts/sound.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Icon</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/tileset.html
+++ b/doc/scripts/tileset.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Tileset</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/triggers.html
+++ b/doc/scripts/triggers.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: Triggers</title>
     <meta name="Keyword" content="ccl,tileset">

--- a/doc/scripts/ui.html
+++ b/doc/scripts/ui.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: User Interface (UI)</title>
     <meta name="Author" content="johns98@gmx.net">

--- a/doc/scripts/unittype.html
+++ b/doc/scripts/unittype.html
@@ -14,8 +14,8 @@
 ----
 ----    You should have received a copy of the GNU General Public License
 ----    along with this program; if not, write to the Free Software
-----    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-----    02111-1307, USA.
+----    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+----    02110-1301, USA.
 -->
     <title>Stratagus Configuration Language Description: UnitType</title>
     <meta name="Author" content="johns98@gmx.net">


### PR DESCRIPTION
Fixed FSF address in documentation.
See also [gnu.org](https://www.gnu.org/licenses/old-licenses/gpl-2.0#SEC4).

Without this fix this leads into a lot of RPMLint warnings when building for openSUSE.