### PR TITLE
Windows 7 crash, added an option to CMake :

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1083,7 +1083,10 @@ add_custom_command(OUTPUT tolua.cpp
 	VERBATIM
 )
 
-add_executable(stratagus WIN32 ${stratagus_SRCS} ${stratagus_HDRS})
+if (ENABLE_STDIO_REDIRECT)
+   add_executable(stratagus WIN32 ${stratagus_SRCS} ${stratagus_HDRS})
+else
+   add_executable(stratagus ${stratagus_SRCS} ${stratagus_HDRS})
 target_link_libraries(stratagus ${stratagus_LIBS})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1085,8 +1085,9 @@ add_custom_command(OUTPUT tolua.cpp
 
 if (ENABLE_STDIO_REDIRECT)
    add_executable(stratagus WIN32 ${stratagus_SRCS} ${stratagus_HDRS})
-else
+else ()
    add_executable(stratagus ${stratagus_SRCS} ${stratagus_HDRS})
+endif ()
 target_link_libraries(stratagus ${stratagus_LIBS})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
If stdio redirection is enabled compile with WIN32 (windows app with no console)
else when no redirection we need a console app to write all the stdio

for : https://github.com/Wargus/wargus/issues/255