### PR TITLE
Don't use AIForce's GoalPos after calling ReturnToHome()

### DIFF
--- a/src/ai/ai_force.cpp
+++ b/src/ai/ai_force.cpp
@@ -1083,6 +1083,12 @@ void AiForceManager::Update()
 						}
 					}
 				}
+
+				if (force.Defending == false) {
+					// force is no longer defending
+					return;
+				}
+
 				// Find idle units and order them to defend
 				// Don't attack if there aren't our units near goal point
 				std::vector<CUnit *> nearGoal;


### PR DESCRIPTION
I get an AccessViolation without this fix. It seems to me that it doesn't make sense to use force.GoalPos after force.ReturnToHome has been called since it's set to -1/-1