### PR TITLE
Fix issue #193 in wargus, Casting on unit portraits

### DIFF
--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -1563,6 +1563,25 @@ static void UISelectStateButtonDown(unsigned)
 
 	if (CursorOn == CursorOnButton) {
 		// FIXME: other buttons?
+		// 74145: Spell-cast on unit portrait
+		if (Selected.size() > 1 && ButtonAreaUnderCursor == ButtonAreaSelected
+			&& CursorAction == ButtonSpellCast) {
+			if (GameObserve || GamePaused || GameEstablishing) {
+				return;
+			}
+			int num = ButtonUnderCursor;
+
+			if (static_cast<size_t>(num) >= Selected.size() || !(MouseButtons & LeftButton)) {
+				return;
+			}
+
+			CUnit &unit = *Selected[num];
+
+			const Vec2i tilePos = unit.tilePos;
+			UnitUnderCursor = &unit;
+			SendSpellCast(tilePos);
+			UnitUnderCursor = NULL;
+		}
 		if (ButtonAreaUnderCursor == ButtonAreaButton) {
 			OldButtonUnderCursor = ButtonUnderCursor;
 			return;


### PR DESCRIPTION
https://github.com/Wargus/wargus/issues/193

This allows clicking on a unit icon (portrait) to cast a spell.

Test:
Get 2 paladins that know the healing spell.
Make sure one is wounded.
Select both of them.
Click healing or the H button.
Select the wounded paladin from the left toolbar (instead of clicking on the main map).
The wounded paladin should be healed.

I'm new, please be nice :-)