### PR TITLE
Fix issue #266 in wargus, Minimap not updated after buildings destroyed

### DIFF
--- a/src/map/minimap.cpp
+++ b/src/map/minimap.cpp
@@ -598,7 +598,7 @@ void CMinimap::Update()
 	//
 	for (CUnitManager::Iterator it = UnitManager.begin(); it != UnitManager.end(); ++it) {
 		CUnit &unit = **it;
-		if (unit.IsVisibleOnMinimap()) {
+		if (unit.IsVisibleOnMinimap() && !unit.Removed) {
 			DrawUnitOn(unit, red_phase);
 		}
 	}


### PR DESCRIPTION
https://github.com/Wargus/wargus/issues/266

Seen buildings did not get removed from minimap when destroyed while under fog of war.

Test:
Create a map in the editor where one computer has some farms, another has grunts and you have a zeppelin.
Play the map in free for all, with fog of war enabled.
Scout out the farm, then pull away and wait for the grunts to finish it.
After some time the farms are removed from the main view.
(And with this patch, they are removed from the minimap as well).