### PR TITLE
enable autocast during attack-move

### DIFF
--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -605,6 +605,11 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 		unit.Waiting = 0;
 	}
 
+	if (this->State != ATTACK_TARGET && unit.CanStoreOrder(this) && AutoCast(unit)) {
+		this->Finished = true;
+		return;
+	}
+
 	switch (this->State) {
 		case 0: { // First entry
 			// did Order change ?


### PR DESCRIPTION
https://github.com/Wargus/wargus/issues/175

Allows autocast to trigger during an attack-move.
(I assume this to mean anytime the unit has the attack order, but not actually attacking something.)
Perhaps it must be configurable?
And should it also trigger while attacking?
Or should it not trigger when you target attack a unit?