### PR TITLE
Various small ui/gfx/sound fixes

### DIFF
--- a/src/action/action_built.cpp
+++ b/src/action/action_built.cpp
@@ -267,6 +267,11 @@ static void Finish(COrder_Built &order, CUnit &unit)
 
 	const int maxProgress = type.Stats[unit.Player->Index].Costs[TimeCost] * 600;
 
+	// Check if we should make some random noise
+	if (unit.Frame == 0 && unit.Player == ThisPlayer && GameCycle % 150 == 0 && SyncRand(3) == 0) {
+		PlayUnitSound(unit, VoiceBuilding, true);
+	}
+
 	// Check if building ready. Note we can both build and repair.
 	if (!unit.Anim.Unbreakable && this->ProgressCounter >= maxProgress) {
 		Finish(*this, unit);

--- a/src/action/action_move.cpp
+++ b/src/action/action_move.cpp
@@ -170,13 +170,22 @@ int DoActionMove(CUnit &unit)
 		}
 
 		if (unit.Type->UnitType == UnitTypeNaval) { // Boat (un)docking?
-			const CMapField &mf_cur = *Map.Field(unit.Offset);
-			const CMapField &mf_next = *Map.Field(unit.tilePos + posd);
+			bool foundCoast = false;
 
-			if (mf_cur.WaterOnMap() && mf_next.CoastOnMap()) {
-				PlayUnitSound(unit, VoiceDocking);
-			} else if (mf_cur.CoastOnMap() && mf_next.WaterOnMap()) {
-				PlayUnitSound(unit, VoiceDocking); // undocking
+			for (int i = 0; i < unit.Type->TileWidth && !foundCoast; i++) {
+				for (int j = 0; j < unit.Type->TileHeight && !foundCoast; j++) {
+					const Vec2i offset(i, j);
+					const CMapField &mf_next = *Map.Field(unit.tilePos + posd + offset);
+					const CMapField &mf_cur = *Map.Field(unit.tilePos + offset);
+
+					if (mf_cur.CoastOnMap() || mf_next.CoastOnMap()) {
+						foundCoast = true;
+					}
+				}
+			}
+			if (foundCoast) {
+				// Should play, even if unit already speaking
+				PlayUnitSound(unit, VoiceDocking, true);
 			}
 		}
 		Vec2i pos = unit.tilePos + posd;

--- a/src/include/missile.h
+++ b/src/include/missile.h
@@ -462,7 +462,7 @@ public:
 	static unsigned int Count; /// slot number generator.
 };
 
-extern bool MissileInitMove(Missile &missile);
+extern bool MissileInitMove(Missile &missile, bool pointToPoint = false);
 extern bool PointToPointMissile(Missile &missile);
 extern void MissileHandlePierce(Missile &missile, const Vec2i &pos);
 extern bool MissileHandleBlocking(Missile &missile, const PixelPos &position);

--- a/src/include/sound.h
+++ b/src/include/sound.h
@@ -166,7 +166,7 @@ extern int DistanceSilent;
 /// Calculates volume level
 extern unsigned char CalculateVolume(bool isVolume, int power, unsigned char range);
 /// Play a unit sound
-extern void PlayUnitSound(const CUnit &unit, UnitVoiceGroup unit_voice_group);
+extern void PlayUnitSound(const CUnit &unit, UnitVoiceGroup unit_voice_group, bool sampleUnique = false);
 /// Play a unit sound
 extern void PlayUnitSound(const CUnit &unit, CSound *sound);
 /// Play a missile sound

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -490,7 +490,7 @@ void CMap::FixTile(unsigned short type, int seen, const Vec2i &pos)
 	}
 
 	//maybe isExplored
-	if (mf.playerInfo.IsExplored(*ThisPlayer)) {
+	if (mf.playerInfo.IsTeamVisible(*ThisPlayer)) {
 		UI.Minimap.UpdateSeenXY(pos);
 		if (!seen) {
 			MarkSeenTile(mf);
@@ -529,7 +529,7 @@ void CMap::ClearWoodTile(const Vec2i &pos)
 	FixNeighbors(MapFieldForest, 0, pos);
 
 	//maybe isExplored
-	if (mf.playerInfo.IsExplored(*ThisPlayer)) {
+	if (mf.playerInfo.IsTeamVisible(*ThisPlayer)) {
 		UI.Minimap.UpdateSeenXY(pos);
 		MarkSeenTile(mf);
 	}
@@ -547,7 +547,7 @@ void CMap::ClearRockTile(const Vec2i &pos)
 	FixNeighbors(MapFieldRocks, 0, pos);
 
 	//maybe isExplored
-	if (mf.playerInfo.IsExplored(*ThisPlayer)) {
+	if (mf.playerInfo.IsTeamVisible(*ThisPlayer)) {
 		UI.Minimap.UpdateSeenXY(pos);
 		MarkSeenTile(mf);
 	}

--- a/src/map/minimap.cpp
+++ b/src/map/minimap.cpp
@@ -598,7 +598,7 @@ void CMinimap::Update()
 	//
 	for (CUnitManager::Iterator it = UnitManager.begin(); it != UnitManager.end(); ++it) {
 		CUnit &unit = **it;
-		if (unit.IsVisibleOnMinimap() && !unit.Removed) {
+		if (unit.IsVisibleOnMinimap() && !unit.Removed && !unit.Type->BoolFlag[REVEALER_INDEX].value) {
 			DrawUnitOn(unit, red_phase);
 		}
 	}

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -400,6 +400,7 @@ void FireMissile(CUnit &unit, CUnit *goal, const Vec2i &goalPos)
 								   + unit.Type->MissileOffsets[dir][0];
 
 	Vec2i dpos;
+	bool divisionOffset = false;
 	if (goal) {
 		Assert(goal->Type);  // Target invalid?
 		// Moved out of attack range?
@@ -415,6 +416,8 @@ void FireMissile(CUnit &unit, CUnit *goal, const Vec2i &goalPos)
 		if (unit.Container) {
 			NearestOfUnit(*goal, GetFirstContainer(unit)->tilePos, &dpos);
 		} else {
+			if (goal->Type->TileWidth % 2 == 0)
+				divisionOffset = true;
 			dpos = goal->tilePos + goal->Type->GetHalfTileSize();
 		}
 	} else {
@@ -423,6 +426,8 @@ void FireMissile(CUnit &unit, CUnit *goal, const Vec2i &goalPos)
 	}
 
 	PixelPos destPixelPos = Map.TilePosToMapPixelPos_Center(dpos);
+	if (divisionOffset)
+		destPixelPos -= PixelTileSize/2;
 	Missile *missile = MakeMissile(*unit.Type->Missile.Missile, startPixelPos, destPixelPos);
 	//
 	// Damage of missile
@@ -632,9 +637,10 @@ void Missile::MissileNewHeadingFromXY(const PixelPos &delta)
 **
 **  @return         true if goal is reached, false else.
 */
-bool MissileInitMove(Missile &missile)
+bool MissileInitMove(Missile &missile, bool pointToPoint)
 {
-	const PixelPos heading = missile.destination - missile.position;
+	const PixelPos source = pointToPoint ? missile.source : missile.position;
+	const PixelPos heading = missile.destination - source;
 
 	missile.MissileNewHeadingFromXY(heading);
 	if (!(missile.State & 1)) {
@@ -740,7 +746,7 @@ bool MissileHandleBlocking(Missile &missile, const PixelPos &position)
 */
 bool PointToPointMissile(Missile &missile)
 {
-	MissileInitMove(missile);
+	MissileInitMove(missile, true);
 	if (missile.TotalStep == 0) {
 		return true;
 	}

--- a/src/sound/sound.cpp
+++ b/src/sound/sound.cpp
@@ -278,7 +278,7 @@ static char CalculateStereo(const CUnit &unit)
 **  @param unit   Sound initiator, unit speaking
 **  @param voice  Type of sound wanted (Ready,Die,Yes,...)
 */
-void PlayUnitSound(const CUnit &unit, UnitVoiceGroup voice)
+void PlayUnitSound(const CUnit &unit, UnitVoiceGroup voice, bool sampleUnique)
 {
 	CSound *sound = ChooseUnitVoiceSound(unit, voice);
 	if (!sound) {
@@ -288,11 +288,17 @@ void PlayUnitSound(const CUnit &unit, UnitVoiceGroup voice)
 	bool selection = (voice == VoiceSelected || voice == VoiceBuilding);
 	Origin source = {&unit, unsigned(UnitNumber(unit))};
 
-	if (UnitSoundIsPlaying(&source)) {
+	if (!sampleUnique && UnitSoundIsPlaying(&source)) {
 		return;
 	}
 
-	int channel = PlaySample(ChooseSample(sound, selection, source), &source);
+	CSample *sample = ChooseSample(sound, selection, source);
+
+	if (sampleUnique && SampleIsPlaying(sample)) {
+		return;
+	}
+
+	int channel = PlaySample(sample, &source);
 	if (channel == -1) {
 		return;
 	}

--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -730,7 +730,10 @@ static void DrawInformations(const CUnit &unit, const CUnitType &type, const Pix
 
 	// FIXME: johns: ugly check here, should be removed!
 	if (unit.CurrentAction() != UnitActionDie && (unit.IsVisible(*ThisPlayer) || ReplayRevealMap)) {
-		DrawDecoration(unit, type, screenPos);
+		PixelPos offsetPos(screenPos);
+		if (unit.tilePos.y == Map.Info.MapHeight-1)
+			offsetPos.y -= 2;
+		DrawDecoration(unit, type, offsetPos);
 	}
 }
 

--- a/src/video/sdl.cpp
+++ b/src/video/sdl.cpp
@@ -884,13 +884,13 @@ static void SdlDoEvent(const EventCallback &callbacks, SDL_Event &event)
 					IsSDLWindowVisible = false;
 					if (!GamePaused) {
 						DoTogglePause = true;
-						UiTogglePause();
+						GamePaused = true;
 					}
 				} else if (!IsSDLWindowVisible && event.active.gain) {
 					IsSDLWindowVisible = true;
 					if (GamePaused && DoTogglePause) {
 						DoTogglePause = false;
-						UiTogglePause();
+						GamePaused = false;
 					}
 				}
 			}


### PR DESCRIPTION
* Don't let pointtopoint missiles wobble
* Don't spam "Game Resumed" from SDL
^ On my laptop, I kept getting "Game Resumed" popping up on the status bar.
* Hack to make mana visible for units on bottom row
* Play transport docking sound more reliably
* Play random building noises
* Don't show wood being cut under fog of war
* Fix wood not updated by ally vision
* Fix "revealer unit" visible on minimap when casting holy vision in wargus.
* Fix missile not targeting center of 2x2 and 4x4 units.