### PR TITLE
fixes for terrain-harvester and maybe lose-resources

### DIFF
--- a/src/action/action_resource.cpp
+++ b/src/action/action_resource.cpp
@@ -167,6 +167,15 @@ static bool FindNearestReachableTerrainType(int movemask, int resmask, int range
 	order->CurrentResource = harvester.CurrentResource;
 	order->DoneHarvesting = true;
 
+	if (harvester.CurrentResource) {
+		const ResourceInfo &resinfo = *harvester.Type->ResInfo[harvester.CurrentResource];
+		if (resinfo.TerrainHarvester && harvester.ResourcesHeld < resinfo.ResourceCapacity) {
+			// Need to finish harvesting first!
+			delete order;
+			return NewActionResource(harvester, harvester.tilePos);
+		}
+	}
+
 	if (depot == NULL) {
 		depot = FindDeposit(harvester, 1000, harvester.CurrentResource);
 	}
@@ -345,6 +354,11 @@ COrder_Resource::~COrder_Resource()
 	}
 	if (this->IsGatheringStarted()  && unit.ResourcesHeld > 0) {
 		// escape to Depot with what you have
+		const ResourceInfo &resinfo = *unit.Type->ResInfo[this->CurrentResource];
+		if (resinfo.TerrainHarvester && unit.ResourcesHeld < resinfo.ResourceCapacity) {
+			// We don't have anything yet.
+			return false;
+		}
 		this->DoneHarvesting = true;
 		return true;
 	}

--- a/src/action/actions.cpp
+++ b/src/action/actions.cpp
@@ -400,6 +400,14 @@ static void HandleUnitAction(CUnit &unit)
 				SelectedUnitChanged();
 			}
 		}
+		if (unit.CurrentResource) {
+			const ResourceInfo &resinfo = *unit.Type->ResInfo[unit.CurrentResource];
+			if (resinfo.LoseResources && unit.Orders[0]->Action != UnitActionResource
+				&& (!resinfo.TerrainHarvester || unit.ResourcesHeld < resinfo.ResourceCapacity)) {
+				unit.CurrentResource = 0;
+				unit.ResourcesHeld = 0;
+			}
+		}
 	}
 	unit.Orders[0]->Execute(unit);
 }

--- a/src/ui/botpanel.cpp
+++ b/src/ui/botpanel.cpp
@@ -892,17 +892,14 @@ bool IsButtonAllowed(const CUnit &unit, const ButtonAction &buttonaction)
 			break;
 		case ButtonHarvest:
 			if (!unit.CurrentResource
-				|| !(unit.ResourcesHeld > 0 && !unit.Type->ResInfo[unit.CurrentResource]->LoseResources)
-				|| (unit.ResourcesHeld != unit.Type->ResInfo[unit.CurrentResource]->ResourceCapacity
-					&& unit.Type->ResInfo[unit.CurrentResource]->LoseResources)) {
+				|| unit.ResourcesHeld < unit.Type->ResInfo[unit.CurrentResource]->ResourceCapacity) {
 				res = true;
 			}
 			break;
 		case ButtonReturn:
-			if (!(!unit.CurrentResource
-				  || !(unit.ResourcesHeld > 0 && !unit.Type->ResInfo[unit.CurrentResource]->LoseResources)
-				  || (unit.ResourcesHeld != unit.Type->ResInfo[unit.CurrentResource]->ResourceCapacity
-					  && unit.Type->ResInfo[unit.CurrentResource]->LoseResources))) {
+		    if (unit.CurrentResource
+		        && ((unit.ResourcesHeld > 0 && !unit.Type->ResInfo[unit.CurrentResource]->TerrainHarvester)
+		            || (unit.ResourcesHeld >= unit.Type->ResInfo[unit.CurrentResource]->ResourceCapacity))) {
 				res = true;
 			}
 			break;


### PR DESCRIPTION
Previously, it was possible to tell a unit to return goods with the terrain-harvester trait before it reached full capacity.
The effect was that the terrain was left intact and the worker would return what it had mined so far.
Thus you could get unlimited amount of resources from the same terrain tile (we don't track resources in terrain).

Also partially implemented the 'lose-resources' trait. I'm not exactly sure how it's supposed to work, but now kinda does what it says it should do in comments/doc.
Perhaps it should also be triggered in COrder_Resource::LoseResource ..?
But, then we might need to develop the terrain-harvester some more first. (workers cut the same tree in wargus, in original they try hard to spread out).