### PR TITLE
check dependencies for ai when upgrading

### DIFF
--- a/src/ai/ai_resource.cpp
+++ b/src/ai/ai_resource.cpp
@@ -778,12 +778,14 @@ void AiAddResearchRequest(CUpgrade *upgrade)
 **  @param what  To what should be upgraded.
 **
 **  @return      True if made, false if can't be made.
-**
-**  @note        We must check if the dependencies are fulfilled.
 */
 static bool AiUpgradeTo(const CUnitType &type, CUnitType &what)
 {
 	std::vector<CUnit *> table;
+
+	if (!CheckDependByType(*AiPlayer->Player, what)) {
+		return false;
+	}
 
 	// Remove all units already doing something.
 	FindPlayerUnitsByType(*AiPlayer->Player, type, table, true);


### PR DESCRIPTION
Previously the AI would cheat if instructed to upgrade city hall before it could with AiUpgradeTo.
Land/Sea/Air AI still works with this patch at least.. didn't test campaign.