### PR TITLE
Increase buffersize due to possible overflow

### DIFF
--- a/src/ui/mainscr.cpp
+++ b/src/ui/mainscr.cpp
@@ -1149,7 +1149,7 @@ static void InfoPanel_draw_multiple_selection()
 		}
 	}
 	if (Selected.size() > UI.SelectedButtons.size()) {
-		char buf[5];
+		char buf[22];
 
 		sprintf(buf, "+%lu", (long unsigned int)(Selected.size() - UI.SelectedButtons.size()));
 		CLabel(*UI.MaxSelectedFont).Draw(UI.MaxSelectedTextX, UI.MaxSelectedTextY, buf);


### PR DESCRIPTION
Hey guys.

Using gcc version 7.4.0 I get a warning in CInfoPanel::Draw() in src/ui/mainscr.cpp when building in release configuration. Anybody else having that problem?

_stratagus/src/ui/mainscr.cpp:1168:6: error: ‘%lu’ directive writing between 1 and 20 bytes into a region of size 5 [-Werror=format-overflow=]_

Increasing the buffersize to 22 solves the problem for me.

Regards

David
