### PR TITLE
Missiles spawn position fix. Moved to the center of unit.

### DIFF
--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -396,7 +396,7 @@ void FireMissile(CUnit &unit, CUnit *goal, const Vec2i &goalPos)
 	// If Firing from inside a Bunker
 	CUnit *from = GetFirstContainer(unit);
 	const int dir = ((unit.Direction + NextDirection / 2) & 0xFF) / NextDirection;
-	const PixelPos startPixelPos = Map.TilePosToMapPixelPos_Center(from->tilePos)
+	const PixelPos startPixelPos = from->GetMapPixelPosCenter()
 								   + unit.Type->MissileOffsets[dir][0];
 
 	Vec2i dpos;


### PR DESCRIPTION
Now missiles spawn in the center of **unit**, not in the center of the unit's **map tile**. For units larger than 1x1 tile that looked weird - missile launches from top left tile.

Offset (if needed for fine tuning) must be set in the units declaration lua-files by MissileOffsets = {}.

There was PR https://github.com/Wargus/wargus/pull/307 which moved origin point for towers to their center. It added {16,16} offset to Stratagus calculated center for 32x32 map tile where the unit are, as a result we had origin poinf for missiles at bottom right corner of upper left tile - exactly center of 2x2 tile tower. But, these offsets was added for other units too, and broke their missile origin points - they are moved to the right and down.


