### PR TITLE
Allow spaces in the maps filenames for network games.

### DIFF
--- a/src/network/netconnect.cpp
+++ b/src/network/netconnect.cpp
@@ -734,7 +734,7 @@ static bool IsSafeMapName(const char *mapname)
 
 	for (const char *ch = buf; *ch != '\0'; ++ch) {
 		if (!isalnum(*ch) && *ch != '/' && *ch != '.' && *ch != '-'
-			&& *ch != '(' && *ch != ')' && *ch != '_') {
+			&& *ch != '(' && *ch != ')' && *ch != '_' && *ch != ' ') {
 			return false;
 		}
 	}


### PR DESCRIPTION
There is an issue with connecting to network game - client rejected to connect if selected map contains spaces in it's path/file_name. 

This allow spaces in the map's filenames.