### PR TITLE
Automatic Targeting.

### DIFF
--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -418,19 +418,17 @@ bool COrder_Attack::CheckForTargetInRange(CUnit &unit)
 		return true;
 	}
 
-	if (this->State && !(this->State & AUTO_TARGETING)) {
-		if (!this->HasGoal() || !this->GetGoal()->IsAlive()){
-			this->Finished = true;
-			return true;
-		}
+	if (!this->HasGoal() && !(this->State & AUTO_TARGETING)){
+		this->Finished = true;
+		return true;
 	}
-
+	
 	if (this->State & AUTO_TARGETING || unit.Player->AiEnabled) {
 		CUnit *goal = this->GetGoal();
 		CUnit *newTarget = AttackUnitsInReactRange(unit);
 		if (newTarget) {
 			if (!goal
-				|| (goal && ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal))) {
+				|| ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal)) {
 
 				SetAutoTarget(unit, newTarget);					
 			}
@@ -540,26 +538,25 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 	if (CheckForDeadGoal(unit)) {
 		return;
 	}
-	CUnit *goal = this->GetGoal();
-	
-	bool dead = !goal || goal->IsAlive() == false;
-	if (dead && !(this->State & AUTO_TARGETING)){
+	if (!this->HasGoal() && !(this->State & AUTO_TARGETING)){
 		this->Finished = true;
 		return;
 	}
-
+	
+	CUnit *goal = this->GetGoal();
 	if (this->State & AUTO_TARGETING || unit.Player->AiEnabled) {
 		CUnit *newTarget = AttackUnitsInReactRange(unit);
 		if (newTarget) {
 			if (!goal
-				|| (goal && ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal))) {
+				|| ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal)) {
 
 				SetAutoTarget(unit, newTarget);
 				goal = newTarget;
 				this->State = MOVE_TO_TARGET | AUTO_TARGETING;			
 				}
 		}
-		if (!goal && unit.RestoreOrder()) {
+		if (!goal) {
+		 	unit.RestoreOrder();
 			return;
 		}		
 	}

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -630,11 +630,7 @@ bool COrder_Attack::IsTargetTooClose(const CUnit &unit) const
 */
 void COrder_Attack::MoveToAttackPos(CUnit &unit, const int pfReturn)
 {
-	Assert(!unit.Type->BoolFlag[VANISHES_INDEX].value && !unit.Destroyed && !unit.Removed);
-	Assert(unit.CurrentOrder() == this);
-	Assert(unit.CanMove());
 	Assert(IsMovingToAttackPos());
-	Assert(this->HasGoal() || Map.Info.IsPointOnMap(this->goalPos));
 
 	if (CheckForTargetInRange(unit)) {
 		return;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -479,7 +479,7 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 		if (this->offeredTarget->IsVisibleAsGoal(*unit.Player)
 			&& (!immobile || InAttackRange(unit, *this->offeredTarget))) {
 
-			newTarget = newTarget ? BestTarget(unit, this->offeredTarget, newTarget) : this->offeredTarget;
+			newTarget = newTarget ? BestTarget(unit, this->offeredTarget, newTarget) : &(*this->offeredTarget);
 		}
 		this->offeredTarget.Reset();
 	}
@@ -541,7 +541,7 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 bool COrder_Attack::EndActionAttack(CUnit &unit, const bool canBeFinished = true)
 {
 	/// Restore saved order only when UnderAttack counter is expired
-	if (unit.UnderAttack || !unit.RestoreOrder()) {
+	if ((unit.UnderAttack && IsAutoTargeting()) || !unit.RestoreOrder()) {
 		if (IsAutoTargeting() && this->goalPos != this->attackMovePos) {
 			this->goalPos 	= this->attackMovePos;
 			this->Range 	= 0;
@@ -715,10 +715,12 @@ void COrder_Attack::MoveToTarget(CUnit &unit)
 			if (currGoal && goal != currGoal) {
 				if (InAttackRange(unit, *currGoal)) {
 					TurnToTarget(unit, currGoal);
-					this->State = ATTACK_TARGET | AUTO_TARGETING;
+					this->State &= AUTO_TARGETING;
+					this->State |= ATTACK_TARGET ;
 				} else {
 					unit.Frame	= 0;
-					this->State = MOVE_TO_TARGET | AUTO_TARGETING;
+					this->State &= AUTO_TARGETING;
+					this->State |= MOVE_TO_TARGET;
 				}
 			}
 		}

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -471,11 +471,16 @@ bool COrder_Attack::EndActionAttack(CUnit &unit, const bool canBeFinished = true
 	return false;
 }
 
+/**
+**  Move unit to randomly selected position in MinAttackRange away from current goal.
+**
+**  @param unit  Unit ot move
+*/
 void COrder_Attack::MoveToBetterPos(CUnit &unit)
 {
 	Assert(this->HasGoal());
 
-	CUnit *goal = this->GetGoal();
+	CUnit *goal 	= this->GetGoal();
 	this->goalPos 	= PosToRetreat(unit, *goal, unit.Type->MinAttackRange + 1);
 	this->Range		= 0;
 	this->MinRange 	= 0;
@@ -504,7 +509,7 @@ bool COrder_Attack::CheckForTargetInRange(CUnit &unit)
 	}
 	
 	if (IsAutoTargeting() || unit.Player->AiEnabled) {
-		static bool hadGoal = this->HasGoal();
+		const bool hadGoal = this->HasGoal();
 		if (!AutoSelectTarget(unit) && hadGoal) {
 			EndActionAttack(unit, RESTORE_ONLY);
 			return true;
@@ -517,6 +522,8 @@ bool COrder_Attack::CheckForTargetInRange(CUnit &unit)
 
 /**
 **  Controls moving a unit to its target when attacking
+**
+**	@todo FIXME: add move to better pos for Attack_Ground when target tile is too close
 **
 **  @param unit  Unit that is attacking and moving
 */
@@ -640,7 +647,6 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 			return;
 		}
 	}
-	// FIXME: What to do when Distance < MinAttackRange?
 	CUnit *goal = this->GetGoal();
 	if (!InAttackRange(unit, *goal)) {
 		unit.Frame 	= 0;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -334,6 +334,9 @@ inline bool COrder_Attack::IsAttackGroundOrWall() const
 
 CUnit *const COrder_Attack::BestTarget(const CUnit &unit, CUnit *const target1, CUnit *const target2) const
 {
+	Assert(target1 != NULL);
+	Assert(target2 != NULL);
+
 	return (Preference.SimplifiedAutoTargeting 
 				? ((TargetPriorityCalculate(&unit, target1) > TargetPriorityCalculate(&unit, target2)) ? target1 : target2)
 				: ((ThreatCalculate(unit, *target1) < ThreatCalculate(unit, *target2)) ?  target1 : target2));
@@ -476,7 +479,7 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 		if (this->offeredTarget->IsVisibleAsGoal(*unit.Player)
 			&& (!immobile || InAttackRange(unit, *this->offeredTarget))) {
 
-			newTarget = newTarget ? BestTarget(unit, this->offeredTarget, newTarget) : NULL;
+			newTarget = newTarget ? BestTarget(unit, this->offeredTarget, newTarget) : this->offeredTarget;
 		}
 		this->offeredTarget.Reset();
 	}

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -313,20 +313,19 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 	return false;
 }
 
-
-inline bool COrder_Attack::IsWeakTargetSelected() const
+bool COrder_Attack::IsWeakTargetSelected() const
 {
 	return (this->State & AUTO_TARGETING) != 0;
 }
-inline bool COrder_Attack::IsAutoTargeting() const
+bool COrder_Attack::IsAutoTargeting() const
 {
 	return (this->State & AUTO_TARGETING) != 0;
 }
-inline bool COrder_Attack::IsMovingToAttackPos() const
+bool COrder_Attack::IsMovingToAttackPos() const
 {
 	return (this->State & MOVE_TO_ATTACKPOS) != 0;
 }
-inline bool COrder_Attack::IsAttackGroundOrWall() const
+bool COrder_Attack::IsAttackGroundOrWall() const
 {
 	/// FIXME: Check if need to add this: (goal && goal->Type && goal->Type->BoolFlag[WALL_INDEX].value)	
 	return (this->Action == UnitActionAttackGround || Map.WallOnMap(this->goalPos) ? true : false);

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -495,9 +495,8 @@ void COrder_Attack::MoveToBetterPos(CUnit &unit)
 	if (!goal && IsAttackGroundOrWall()) {
 		this->attackMovePos = this->goalPos;
 	}
-	this->goalPos 	= goal ? PosToRetreat(unit, *goal, unit.Type->MinAttackRange + 1) 
-							: PosToRetreat(unit, this->goalPos, unit.Type->MinAttackRange + 1);
-	
+	this->goalPos 	= goal	? GetRndPosInDirection(unit.tilePos, goal, true, unit.Type->MinAttackRange + 1, 3)
+							: GetRndPosInDirection(unit.tilePos, this->goalPos, true, unit.Type->MinAttackRange + 1, 3);
 	this->Range		= 0;
 	this->MinRange 	= 0;
 	unit.Frame 	  	= 0;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -214,23 +214,23 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 	PixelPos targetPos;
 	PixelPos orderedPos;
 
-	if (this->HasGoal()) {
-		targetPos = vp.MapToScreenPixelPos(this->GetGoal()->GetMapPixelPosCenter());
-	} else {
-		targetPos = vp.TilePosToScreen_Center(this->goalPos);
+	targetPos = this->HasGoal() ? vp.MapToScreenPixelPos(this->GetGoal()->GetMapPixelPosCenter())
+								: vp.TilePosToScreen_Center(this->goalPos);
+
+	orderedPos = this->isAttackMove ? vp.TilePosToScreen_Center(this->attackMovePos)
+									: targetPos;
+	
+	Uint32 color = this->isAttackMove ? ColorOrange : ColorRed;
+	Video.FillCircleClip(color, lastScreenPos, 2);
+	Video.DrawLineClip(ColorRed, lastScreenPos, orderedPos);
+	Video.FillCircleClip(color, orderedPos, 3);
+
+	if (this->isAttackMove && this->HasGoal()){
+		Video.DrawLineClip(ColorOrange, lastScreenPos, targetPos);
+		Video.FillCircleClip(ColorOrange, targetPos, 3);
 	}
 
-	Video.FillCircleClip(this->isAttackMove  ? ColorOrange : ColorRed, lastScreenPos, 2);
-	Video.DrawLineClip(this->isAttackMove ? ColorOrange : ColorRed, lastScreenPos, targetPos);
-	Video.FillCircleClip(this->isAttackMove && this->HasGoal() ? ColorOrange : ColorRed, targetPos, 3);
-
-	if (this->isAttackMove && this->goalPos != this->attackMovePos){
-		orderedPos = vp.TilePosToScreen_Center(this->attackMovePos);
-		Video.DrawLineClip(ColorOrange, targetPos, orderedPos);
-		Video.FillCircleClip(ColorRed, orderedPos, 3);
-	}
-
-	return (this->isAttackMove && this->HasGoal()) ? orderedPos : targetPos;
+	return this->isAttackMove ? orderedPos : targetPos;
 }
 
 /* virtual */ void COrder_Attack::UpdatePathFinderData(PathFinderInput &input)

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -63,11 +63,12 @@
 --  Defines
 ----------------------------------------------------------------------------*/
 
+#define FIRST_ENTRY		 0
 #define AUTO_TARGETING   2  /// Targets will be selected by small (unit's) AI
 #define MOVE_TO_TARGET   4  /// Move to target state
 #define ATTACK_TARGET    5  /// Attack target state
 
-#define RESTORE_ONLY false
+#define RESTORE_ONLY false  /// Do not finish this order, only restore saved
 
 /*----------------------------------------------------------------------------
 --  Functions
@@ -610,9 +611,9 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 	}
 
 	switch (this->State) {
-		case 0:  
-		case AUTO_TARGETING:// First entry
-			// did Order change ?
+		case FIRST_ENTRY:  
+		case AUTO_TARGETING:
+			
 			if (CheckForTargetInRange(unit)) {
 				return;
 			}

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -280,7 +280,10 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 }
 
 
-
+bool COrder_Attack::IsWeakTargetSelected() const
+{
+	return (this->State & AUTO_TARGETING) != 0;
+}
 bool COrder_Attack::IsAutoTargeting() const
 {
 	return (this->State & AUTO_TARGETING) != 0;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -434,13 +434,19 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 				const int newTarget_priority 	= TargetPriorityCalculate(&unit, newTarget);
 
 				if ((newTarget_priority & AT_PRIORITY_MASK_HI) > (goal_priority & AT_PRIORITY_MASK_HI)) {
-					SetAutoTarget(unit, newTarget);
+					if (goal_priority & AT_ATTACKED_BY_FACTOR) { /// if unit under attack by current goal
+						if (InAttackRange(unit, *newTarget)) {
+							SetAutoTarget(unit, newTarget);
+						}
+					} else {
+						SetAutoTarget(unit, newTarget);
+					}
 				} else if (!immobile
 						   && (!InAttackRange(unit, *goal) && newTarget_priority > goal_priority)) {
 					SetAutoTarget(unit, newTarget);
 				}
 			} else {
-				if (ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal)) {
+				if (unit.Threshold == 0 && ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal)) {
 					SetAutoTarget(unit, newTarget);
 				}
 			}

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -686,7 +686,9 @@ void COrder_Attack::MoveToTarget(CUnit &unit)
 		MoveToBetterPos(unit);
 		return;	
 	}
-	if (unit.Anim.Unbreakable) {
+	/// Order may be set as finished by outside code while playing animation.
+	/// In this case we must not execute code of MoveToTarget
+	if (unit.Anim.Unbreakable || this->State == Finished) {
 		return;
 	}
 	if (IsMovingToAttackPos()) {
@@ -785,7 +787,7 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 		}
 	}
 	CUnit *goal = this->GetGoal();
-	if (!InAttackRange(unit, *goal)) {
+	if (goal && !InAttackRange(unit, *goal)) {
 		unit.Frame 	= 0;
 		this->State &= AUTO_TARGETING;
 		this->State |= MOVE_TO_TARGET;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -704,7 +704,7 @@ void COrder_Attack::MoveToTarget(CUnit &unit)
 	CUnit *goal = this->GetGoal();
 	// Waiting or on the way
 	if (err >= 0) {
-		if (!CheckForTargetInRange(unit) && IsAutoTargeting()) {
+		if (!CheckForTargetInRange(unit) && (IsAutoTargeting() || unit.Player->AiEnabled)) {
 			CUnit *currGoal = this->GetGoal();
 			if (currGoal && goal != currGoal) {
 				if (InAttackRange(unit, *currGoal)) {

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -165,7 +165,7 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 		file.printf(" \"goal\", \"%s\",", UnitReference(this->GetGoal()).c_str());
 	}
 	file.printf(" \"tile\", {%d, %d},", this->goalPos.x, this->goalPos.y);
-//	file.printf(" \"amove-tile\", {%d, %d},", this->attackMovePos.x, this->attackMovePos.y);
+	file.printf(" \"amove-tile\", {%d, %d},", this->attackMovePos.x, this->attackMovePos.y);
 	file.printf(" \"state\", %d", this->State);
 	file.printf("}");
 }
@@ -189,13 +189,13 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 		lua_rawgeti(l, -1, j + 1);
 		CclGetPos(l, &this->goalPos.x , &this->goalPos.y);
 		lua_pop(l, 1);
-/*		
+		
 	} else if (!strcmp(value, "amove-tile")) {
 		++j;
 		lua_rawgeti(l, -1, j + 1);
 		CclGetPos(l, &this->attackMovePos.x , &this->attackMovePos.y);
 		lua_pop(l, 1);
-*/
+
 	} else {
 		return false;
 	}

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -67,7 +67,7 @@
 #define AUTO_TARGETING   	2  /// Targets will be selected by small (unit's) AI
 #define MOVE_TO_TARGET   	4  /// Move to target state
 #define ATTACK_TARGET    	5  /// Attack target state
-#define MOVE_TO_ATTACKPOS	8  /// Move to position for attack when target is too close
+#define MOVE_TO_ATTACKPOS	8  /// Move to position for attack if target is too close
 
 #define RESTORE_ONLY false  /// Do not finish this order, only restore saved
 

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -107,8 +107,9 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 	order->SetGoal(&target);
 	order->Range = attacker.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	order->MinRange = attacker.Type->MinAttackRange;
-	if (attacker.Type->BoolFlag[SKIRMISHER_INDEX].value)
+	if (attacker.Type->BoolFlag[SKIRMISHER_INDEX].value) {
 		order->SkirmishRange = order->Range;
+	}
 
 	return order;
 }
@@ -129,8 +130,9 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 		order->attackMovePos = dest;
 		order->State = AUTO_TARGETING;
 	}
-	if (attacker.Type->BoolFlag[SKIRMISHER_INDEX].value)
+	if (attacker.Type->BoolFlag[SKIRMISHER_INDEX].value) {
 		order->SkirmishRange = attacker.Stats->Variables[ATTACKRANGE_INDEX].Max;
+	}
 
 	return order;
 }
@@ -142,8 +144,9 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 	order->goalPos = dest;
 	order->Range = attacker.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	order->MinRange = attacker.Type->MinAttackRange;
-	if (attacker.Type->BoolFlag[SKIRMISHER_INDEX].value)
+	if (attacker.Type->BoolFlag[SKIRMISHER_INDEX].value) {
 		order->SkirmishRange = order->Range;
+	}
 
 	return order;
 }
@@ -185,18 +188,19 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 	} else if (!strcmp(value, "range")) {
 		++j;
 		this->Range = LuaToNumber(l, -1, j + 1);
-		if (unit.Type->BoolFlag[SKIRMISHER_INDEX].value)
+		if (unit.Type->BoolFlag[SKIRMISHER_INDEX].value) {
 			this->SkirmishRange = this->Range;
+		}
 	} else if (!strcmp(value, "tile")) {
 		++j;
 		lua_rawgeti(l, -1, j + 1);
-		CclGetPos(l, &this->goalPos.x , &this->goalPos.y);
+		CclGetPos(l, &this->goalPos.x, &this->goalPos.y);
 		lua_pop(l, 1);
 
 	} else if (!strcmp(value, "amove-tile")) {
 		++j;
 		lua_rawgeti(l, -1, j + 1);
-		CclGetPos(l, &this->attackMovePos.x , &this->attackMovePos.y);
+		CclGetPos(l, &this->attackMovePos.x, &this->attackMovePos.y);
 		lua_pop(l, 1);
 
 	} else {
@@ -229,8 +233,8 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 								: vp.TilePosToScreen_Center(this->goalPos);
 
 	orderedPos = isAttackMove ? vp.TilePosToScreen_Center(this->attackMovePos)
-							  : targetPos;
-	
+				 			  : targetPos;
+
 	Uint32 color = isAttackMove ? ColorOrange : ColorRed;
 	Video.FillCircleClip(color, lastScreenPos, 2);
 	Video.DrawLineClip(ColorRed, lastScreenPos, orderedPos);
@@ -263,10 +267,11 @@ void AnimateActionAttack(CUnit &unit, COrder &order)
 		CheckObstaclesBetweenTiles(input.GetUnitPos(), this->HasGoal() ? this->GetGoal()->tilePos : this->goalPos, MapFieldRocks | MapFieldForest, &distance);
 	}
 	input.SetMaxRange(distance);
-	if (!this->SkirmishRange || Distance(input.GetUnitPos(), input.GetGoalPos()) < this->SkirmishRange)
+	if (!this->SkirmishRange || Distance(input.GetUnitPos(), input.GetGoalPos()) < this->SkirmishRange) {
 		input.SetMinRange(this->MinRange);
-	else
+	} else {
 		input.SetMinRange(std::max<int>(this->SkirmishRange, this->MinRange));
+	}
 }
 
 /* virtual */ void COrder_Attack::OnAnimationAttack(CUnit &unit)
@@ -350,7 +355,7 @@ bool COrder_Attack::CheckIfGoalValid(CUnit &unit)
 void COrder_Attack::TurnToTarget(CUnit &unit, const CUnit *target)
 {
 	const Vec2i dir = target ? (target->tilePos + target->Type->GetHalfTileSize() - unit.tilePos)
-							 : (this->goalPos - unit.tilePos);
+					  		 : (this->goalPos - unit.tilePos);
 	const unsigned char oldDir = unit.Direction;
 
 	UnitHeadingFromDeltaXY(unit, dir);
@@ -367,7 +372,7 @@ void COrder_Attack::TurnToTarget(CUnit &unit, const CUnit *target)
 }
 
 /**
-**  Set target for attack in auto-attack mode. 
+**  Set target for attack in auto-attack mode.
 **  Also if there is no active target Attack-Move action will be saved.
 **
 **  @param unit    Attacker.
@@ -383,15 +388,16 @@ void COrder_Attack::SetAutoTarget(CUnit &unit, CUnit *target)
 	this->goalPos 			= target->tilePos;
 	this->Range 			= unit.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	this->MinRange 			= unit.Type->MinAttackRange;
-	if (unit.Type->BoolFlag[SKIRMISHER_INDEX].value)
+	if (unit.Type->BoolFlag[SKIRMISHER_INDEX].value) {
 		this->SkirmishRange = this->Range;
+	}
 }
 
- /**
- ** Select target in auto attack mode
- **
- ** return true if we have a target, false if can't find any 
- **/
+/**
+** Select target in auto attack mode
+**
+** return true if we have a target, false if can't find any
+**/
 bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 {
 	// if unit can't attack, or if unit is not bunkered and removed - exit, no targets
@@ -405,18 +411,18 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 
 	/// if attacker cant't move (stand_ground, building, in a bunker or transport)
 	const bool immobile = (this->Action == UnitActionStandGround || unit.Removed || !unit.CanMove()) ? true : false;
-	
+
 	if (immobile) {
-		newTarget = AttackUnitsInRange(unit); // search for enemies only in attack range 
+		newTarget = AttackUnitsInRange(unit); // search for enemies only in attack range
 	} else {
 		newTarget = AttackUnitsInReactRange(unit); // search for enemies in reaction range
 	}
 
-    if (goal /// if goal is Valid
-		&& goal->IsVisibleAsGoal(*unit.Player) 
+	if (goal /// if goal is Valid
+		&& goal->IsVisibleAsGoal(*unit.Player)
 		&& CanTarget(*unit.Type, *goal->Type)
 		&& (immobile ? InAttackRange(unit, *goal) : InReactRange(unit, *goal))) {
-				
+
 		if (newTarget && newTarget != goal) {
 			if (Preference.SimplifiedAutoTargeting) {
 				const int goal_priority			= TargetPriorityCalculate(&unit, goal);
@@ -425,19 +431,19 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 				if ((newTarget_priority & AT_PRIORITY_MASK_HI) > (goal_priority & AT_PRIORITY_MASK_HI)) {
 					SetAutoTarget(unit, newTarget);
 				} else if (!immobile
-							&& (!InAttackRange(unit, *goal) && newTarget_priority > goal_priority)) {
-							SetAutoTarget(unit, newTarget);
+						   && (!InAttackRange(unit, *goal) && newTarget_priority > goal_priority)) {
+					SetAutoTarget(unit, newTarget);
 				}
 			} else {
 				if (ThreatCalculate(unit, *newTarget) < ThreatCalculate(unit, *goal)) {
 					SetAutoTarget(unit, newTarget);
 				}
 			}
-		}	
+		}
 	} else {
 		if (goal) {
 			this->ClearGoal();
-		} 
+		}
 		if (newTarget) {
 			SetAutoTarget(unit, newTarget);
 		} else {
@@ -450,8 +456,8 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 /**
 **  Restore action/order when current action is finished
 **
-**  @param unit  
-**  @param canBeFinished    False if ony restore order/action needed 
+**  @param unit
+**  @param canBeFinished    False if ony restore order/action needed
 **
 **  @return      			false if order/action restored, true else (if order finished).
 */
@@ -461,7 +467,7 @@ bool COrder_Attack::EndActionAttack(CUnit &unit, const bool canBeFinished = true
 		if (IsAutoTargeting() && this->goalPos != this->attackMovePos) {
 			this->goalPos 	= this->attackMovePos;
 			this->Range 	= 0;
-			this->MinRange 	= 0;				 
+			this->MinRange 	= 0;
 			this->State 	= AUTO_TARGETING;
 			return false;
 		}
@@ -507,7 +513,7 @@ bool COrder_Attack::CheckForTargetInRange(CUnit &unit)
 		EndActionAttack(unit);
 		return true;
 	}
-	
+
 	if (IsAutoTargeting() || unit.Player->AiEnabled) {
 		const bool hadGoal = this->HasGoal();
 		if (!AutoSelectTarget(unit) && hadGoal) {
@@ -553,17 +559,17 @@ void COrder_Attack::MoveToTarget(CUnit &unit)
 	const bool tooClose = (distance && (distance < unit.Type->MinAttackRange)) ? true : false;
 
 	// Waiting or on the way
-	if (err >= 0 ) {
+	if (err >= 0) {
 		bool targetChanged = false;
 		if (!CheckForTargetInRange(unit)) {
 
 			CUnit *currGoal = this->GetGoal();
-		  	if (currGoal && goal != currGoal) {
+			if (currGoal && goal != currGoal) {
 				targetChanged = true;
 			}
-	
-			if((IsAutoTargeting() && targetChanged) || (this->State & MOVE_TO_ATTACKPOS)) {
-	
+
+			if ((IsAutoTargeting() && targetChanged) || (this->State & MOVE_TO_ATTACKPOS)) {
+
 				if (InAttackRange(unit, *currGoal)) {
 					this->goalPos = currGoal->tilePos; // We have to restore in case of MOVE_TO_ATTACKPOS
 					TurnToTarget(unit, currGoal);
@@ -592,7 +598,7 @@ void COrder_Attack::MoveToTarget(CUnit &unit)
 		}
 		// Attacking wall or ground.
 		if (((goal && goal->Type && goal->Type->BoolFlag[WALL_INDEX].value)
-			|| (!goal && (Map.WallOnMap(this->goalPos) || this->Action == UnitActionAttackGround)))
+			 || (!goal && (Map.WallOnMap(this->goalPos) || this->Action == UnitActionAttackGround)))
 			&& InAttackRange(unit, this->goalPos)) {
 
 			// Reached wall or ground, now attacking it
@@ -630,9 +636,9 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 	Assert(this->HasGoal() || Map.Info.IsPointOnMap(this->goalPos));
 
 	AnimateActionAttack(unit, *this);
-	/// Order may be set as finished by outside code while playing attack animation. 
+	/// Order may be set as finished by outside code while playing attack animation.
 	/// In this case we must not execute code of AttackTarget
-	if (unit.Anim.Unbreakable || this->Finished) { 
+	if (unit.Anim.Unbreakable || this->Finished) {
 		return;
 	}
 	if (!this->HasGoal() && (this->Action == UnitActionAttackGround || Map.WallOnMap(this->goalPos))) {
@@ -695,9 +701,9 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 	}
 
 	switch (this->State) {
-		case FIRST_ENTRY:  
+		case FIRST_ENTRY:
 		case AUTO_TARGETING:
-			
+
 			if (CheckForTargetInRange(unit)) {
 				return;
 			}
@@ -712,8 +718,8 @@ void COrder_Attack::AttackTarget(CUnit &unit)
 				}
 			}
 			this->State |= MOVE_TO_TARGET;
-			// FIXME: should use a reachable place to reduce pathfinder time.
-		
+		// FIXME: should use a reachable place to reduce pathfinder time.
+
 		// FALL THROUGH
 		case MOVE_TO_TARGET:
 		case MOVE_TO_TARGET + AUTO_TARGETING:

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -656,7 +656,7 @@ void COrder_Attack::MoveToAttackPos(CUnit &unit, const int pfReturn)
 			this->goalPos = goal->tilePos;
 		} else {
 			this->goalPos = this->attackMovePos;
-			this->attackMovePos = Vec2i(-1,-1);
+			this->attackMovePos = {-1, -1};
 		}
 		TurnToTarget(unit, goal);
 		this->State &= AUTO_TARGETING;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -656,7 +656,7 @@ void COrder_Attack::MoveToAttackPos(CUnit &unit, const int pfReturn)
 			this->goalPos = goal->tilePos;
 		} else {
 			this->goalPos = this->attackMovePos;
-			this->attackMovePos = {-1, -1};
+			this->attackMovePos = Vec2i(-1,-1);
 		}
 		TurnToTarget(unit, goal);
 		this->State &= AUTO_TARGETING;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -440,6 +440,11 @@ void COrder_Attack::SetAutoTarget(CUnit &unit, CUnit *target)
 	if (unit.Type->BoolFlag[SKIRMISHER_INDEX].value) {
 		this->SkirmishRange = this->Range;
 	}
+	// Set threshold value only for aggressive units (Prevent to change target)
+	if (!Preference.SimplifiedAutoTargeting && target->IsAgressive())
+	{
+		unit.Threshold = 30;
+	}
 }
 
 /**

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -501,8 +501,8 @@ void COrder_Attack::MoveToBetterPos(CUnit &unit)
 	if (!goal && IsAttackGroundOrWall()) {
 		this->attackMovePos = this->goalPos;
 	}
-	this->goalPos 	= goal	? GetRndPosInDirection(unit.tilePos, goal, true, unit.Type->MinAttackRange + 1, 3)
-							: GetRndPosInDirection(unit.tilePos, this->goalPos, true, unit.Type->MinAttackRange + 1, 3);
+	this->goalPos 	= goal	? GetRndPosInDirection(unit.tilePos, *goal, true, unit.Type->MinAttackRange, 3)
+							: GetRndPosInDirection(unit.tilePos, this->goalPos, true, unit.Type->MinAttackRange, 3);
 	this->Range		= 0;
 	this->MinRange 	= 0;
 	unit.Frame 	  	= 0;

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -466,6 +466,10 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 	}
 	CUnit *goal = this->GetGoal();
 	CUnit *newTarget = NULL;
+	if (unit.Selected)
+	{
+		DebugPrint("UnderAttack counter: %d \n" _C_ unit.UnderAttack);
+	}
 
 	/// if attacker cant't move (stand_ground, building, in a bunker or transport)
 	const bool immobile = (this->Action == UnitActionStandGround || unit.Removed || !unit.CanMove()) ? true : false;
@@ -498,7 +502,7 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 			if (Preference.SimplifiedAutoTargeting) {
 				const int goal_priority			= TargetPriorityCalculate(&unit, goal);
 				const int newTarget_priority 	= TargetPriorityCalculate(&unit, newTarget);
-				
+
 				if ((newTarget_priority & AT_PRIORITY_MASK_HI) > (goal_priority & AT_PRIORITY_MASK_HI)) {
 					if (goal_priority & AT_ATTACKED_BY_FACTOR) { /// if unit under attack by current goal
 						if (InAttackRange(unit, *newTarget)) {

--- a/src/action/action_attack.cpp
+++ b/src/action/action_attack.cpp
@@ -471,7 +471,7 @@ bool COrder_Attack::AutoSelectTarget(CUnit &unit)
 		if (this->offeredTarget->IsVisibleAsGoal(*unit.Player)
 			&& (!immobile || InAttackRange(unit, *this->offeredTarget))) {
 
-			newTarget = BestTarget(unit, this->offeredTarget, newTarget);
+			newTarget = newTarget ? BestTarget(unit, this->offeredTarget, newTarget) : NULL;
 		}
 		this->offeredTarget.Reset();
 	}

--- a/src/action/action_still.cpp
+++ b/src/action/action_still.cpp
@@ -277,15 +277,24 @@ bool COrder_Still::AutoAttackStand(CUnit &unit)
 	if (unit.Type->CanAttack == false) {
 		return false;
 	}
+	//  FIXME: if bunkers can increase attack range - count it in the distance calculations and target selection.
+	
 	// Removed units can only attack in AttackRange, from bunker
 	CUnit *autoAttackUnit = AttackUnitsInRange(unit);
 
 	if (autoAttackUnit == NULL) {
 		return false;
 	}
+	
+	/*	
+		FIXME: To Calc and Set GoalPos (if target is closer than MinAttackRange)	
+		Only for units which can attack-ground && has a splash attack && can hit current target with splash
+		Else do not attack at all
+	*/
 	// If unit is removed, use containers x and y
 	const CUnit *firstContainer = unit.Container ? unit.Container : &unit;
-	if (firstContainer->MapDistanceTo(*autoAttackUnit) > unit.Stats->Variables[ATTACKRANGE_INDEX].Max) {
+	const int dist = firstContainer->MapDistanceTo(*autoAttackUnit);
+	if (dist > unit.Stats->Variables[ATTACKRANGE_INDEX].Max	|| dist < unit.Type->MinAttackRange) {
 		return false;
 	}
 	if (GameSettings.Inside && CheckObstaclesBetweenTiles(unit.tilePos, autoAttackUnit->tilePos, MapFieldRocks | MapFieldForest) == false) {

--- a/src/action/action_still.cpp
+++ b/src/action/action_still.cpp
@@ -278,16 +278,16 @@ bool COrder_Still::AutoAttackStand(CUnit &unit)
 		return false;
 	}
 	//  FIXME: if bunkers can increase attack range - count it in the distance calculations and target selection.
-	
+
 	// Removed units can only attack in AttackRange, from bunker
 	CUnit *autoAttackUnit = AttackUnitsInRange(unit);
 
 	if (autoAttackUnit == NULL) {
 		return false;
 	}
-	
-	/*	
-		FIXME: To Calc and Set GoalPos (if target is closer than MinAttackRange)	
+
+	/*
+		FIXME: To Calc and Set GoalPos (if target is closer than MinAttackRange)
 		Only for units which can attack-ground && has a splash attack && can hit current target with splash
 		Else do not attack at all
 	*/

--- a/src/action/actions.cpp
+++ b/src/action/actions.cpp
@@ -287,6 +287,9 @@ static void HandleBuffsEachCycle(CUnit &unit)
 	if (--unit.Threshold < 0) {
 		unit.Threshold = 0;
 	}
+	if (--unit.UnderAttack < 0) {
+		unit.UnderAttack = 0;
+	}
 
 	if (unit.Type->CanCastSpell) {
 		// decrease spell countdown timers

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -59,6 +59,7 @@ public:
 	bool IsWeakTargetSelected() const;
 	bool IsAutoTargeting() const;
 	bool IsAttackGroundOrWall() const;
+	bool IsTargetTooClose(const CUnit &unit) const;
 	void OfferNewTarget(const CUnit &unit, CUnit *const target);
 
 private:
@@ -69,7 +70,6 @@ private:
 	void MoveToBetterPos(CUnit &unit);
 	bool AutoSelectTarget(CUnit &unit);
 	bool CheckForTargetInRange(CUnit &unit);
-	bool IsTargetTooClose(CUnit &unit);
 	void MoveToAttackPos(CUnit &unit, const int pfReturn);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -68,6 +68,8 @@ private:
 	void MoveToBetterPos(CUnit &unit);
 	bool AutoSelectTarget(CUnit &unit);
 	bool CheckForTargetInRange(CUnit &unit);
+	bool IsTargetTooClose(CUnit &unit);
+	void MoveToAttackPos(CUnit &unit, int pfReturn);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);
 

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -41,7 +41,7 @@ class COrder_Attack : public COrder
 	friend COrder *COrder::NewActionAttackGround(const CUnit &attacker, const Vec2i &dest);
 public:
 	explicit COrder_Attack(bool ground) : COrder(ground ? UnitActionAttackGround : UnitActionAttack),
-		State(0), MinRange(0), Range(0), SkirmishRange(0), goalPos(-1, -1), attackMovePos(-1, -1) {}
+		State(0), MinRange(0), Range(0), SkirmishRange(0), offeredTarget(NULL), goalPos(-1, -1), attackMovePos(-1, -1) {}
 
 	virtual COrder_Attack *Clone() const { return new COrder_Attack(*this); }
 
@@ -59,6 +59,7 @@ public:
 	bool IsWeakTargetSelected() const;
 	bool IsAutoTargeting() const;
 	bool IsAttackGroundOrWall() const;
+	void OfferNewTarget(const CUnit &unit, CUnit *const target);
 
 private:
 	bool CheckIfGoalValid(CUnit &unit);
@@ -78,6 +79,7 @@ private:
 	int MinRange;
 	int Range;
 	int SkirmishRange;
+	CUnitPtr offeredTarget; // Stores pointer to target offered from outside (f.e. by HitUnit_AttackBack() event). 
 	Vec2i goalPos;		 // Current goal position
 	Vec2i attackMovePos; // If attack-move was ordered
 };

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -64,6 +64,7 @@ private:
 	void TurnToTarget(CUnit &unit, const CUnit *target);
 	void SetAutoTarget(CUnit &unit, CUnit *target);
 	bool EndActionAttack(CUnit &unit, const bool canBeFinished);
+	bool AutoSelectTarget(CUnit &unit);	
 	bool CheckForTargetInRange(CUnit &unit);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -61,6 +61,8 @@ public:
 
 private:
 	bool CheckForDeadGoal(CUnit &unit);
+	void TurnToTarget(CUnit &unit, const CUnit *target);
+	void SetAutoTarget(CUnit &unit, CUnit *target);
 	bool CheckForTargetInRange(CUnit &unit);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -64,6 +64,7 @@ private:
 	void TurnToTarget(CUnit &unit, const CUnit *target);
 	void SetAutoTarget(CUnit &unit, CUnit *target);
 	bool EndActionAttack(CUnit &unit, const bool canBeFinished);
+	void MoveToBetterPos(CUnit &unit);
 	bool AutoSelectTarget(CUnit &unit);	
 	bool CheckForTargetInRange(CUnit &unit);
 	void MoveToTarget(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -65,7 +65,7 @@ private:
 	void SetAutoTarget(CUnit &unit, CUnit *target);
 	bool EndActionAttack(CUnit &unit, const bool canBeFinished);
 	void MoveToBetterPos(CUnit &unit);
-	bool AutoSelectTarget(CUnit &unit);	
+	bool AutoSelectTarget(CUnit &unit);
 	bool CheckForTargetInRange(CUnit &unit);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -69,7 +69,7 @@ private:
 	bool AutoSelectTarget(CUnit &unit);
 	bool CheckForTargetInRange(CUnit &unit);
 	bool IsTargetTooClose(CUnit &unit);
-	void MoveToAttackPos(CUnit &unit, int pfReturn);
+	void MoveToAttackPos(CUnit &unit, const int pfReturn);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);
 

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -57,6 +57,7 @@ public:
 
 	virtual const Vec2i GetGoalPos() const { return goalPos; }
 	bool IsWeakTargetSelected() const;
+	bool IsAutoTargeting() const;
 
 private:
 	bool CheckForDeadGoal(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -41,7 +41,7 @@ class COrder_Attack : public COrder
 	friend COrder *COrder::NewActionAttackGround(const CUnit &attacker, const Vec2i &dest);
 public:
 	explicit COrder_Attack(bool ground) : COrder(ground ? UnitActionAttackGround : UnitActionAttack),
-		State(0), MinRange(0), Range(0), SkirmishRange(0), goalPos(-1, -1), attackMovePos(-1, -1), isAttackMove(false) {}
+		State(0), MinRange(0), Range(0), SkirmishRange(0), goalPos(-1, -1), attackMovePos(-1, -1) {}
 
 	virtual COrder_Attack *Clone() const { return new COrder_Attack(*this); }
 
@@ -74,7 +74,6 @@ private:
 	int SkirmishRange;
 	Vec2i goalPos;		 // Current goal position
 	Vec2i attackMovePos; // If attack-move was ordered
-	bool isAttackMove;
 };
 //@}
 

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -60,9 +60,10 @@ public:
 	bool IsAutoTargeting() const;
 
 private:
-	bool CheckForDeadGoal(CUnit &unit);
+	bool CheckIfGoalValid(CUnit &unit);
 	void TurnToTarget(CUnit &unit, const CUnit *target);
 	void SetAutoTarget(CUnit &unit, CUnit *target);
+	bool EndActionAttack(CUnit &unit, const bool canBeFinished);
 	bool CheckForTargetInRange(CUnit &unit);
 	void MoveToTarget(CUnit &unit);
 	void AttackTarget(CUnit &unit);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -61,6 +61,7 @@ public:
 	bool IsMovingToAttackPos() const;
 	bool IsAttackGroundOrWall() const;
 	bool IsTargetTooClose(const CUnit &unit) const;
+	CUnit *const BestTarget(const CUnit &unit, CUnit *const target1, CUnit *const target2) const;
 	void OfferNewTarget(const CUnit &unit, CUnit *const target);
 
 private:

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -58,6 +58,7 @@ public:
 	virtual const Vec2i GetGoalPos() const { return goalPos; }
 	bool IsWeakTargetSelected() const;
 	bool IsAutoTargeting() const;
+	bool IsMovingToAttackPos() const;
 	bool IsAttackGroundOrWall() const;
 	bool IsTargetTooClose(const CUnit &unit) const;
 	void OfferNewTarget(const CUnit &unit, CUnit *const target);

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -41,7 +41,7 @@ class COrder_Attack : public COrder
 	friend COrder *COrder::NewActionAttackGround(const CUnit &attacker, const Vec2i &dest);
 public:
 	explicit COrder_Attack(bool ground) : COrder(ground ? UnitActionAttackGround : UnitActionAttack),
-		State(0), MinRange(0), Range(0), SkirmishRange(0), goalPos(-1, -1) {}
+		State(0), MinRange(0), Range(0), SkirmishRange(0), goalPos(-1, -1), attackMovePos(-1, -1), isAttackMove(false) {}
 
 	virtual COrder_Attack *Clone() const { return new COrder_Attack(*this); }
 
@@ -70,7 +70,9 @@ private:
 	int MinRange;
 	int Range;
 	int SkirmishRange;
-	Vec2i goalPos;
+	Vec2i goalPos;		 // Current goal position
+	Vec2i attackMovePos; // If attack-move was ordered
+	bool isAttackMove;
 };
 //@}
 

--- a/src/include/action/action_attack.h
+++ b/src/include/action/action_attack.h
@@ -58,6 +58,7 @@ public:
 	virtual const Vec2i GetGoalPos() const { return goalPos; }
 	bool IsWeakTargetSelected() const;
 	bool IsAutoTargeting() const;
+	bool IsAttackGroundOrWall() const;
 
 private:
 	bool CheckIfGoalValid(CUnit &unit);

--- a/src/include/pathfinder.h
+++ b/src/include/pathfinder.h
@@ -221,7 +221,7 @@ extern int NextPathElement(CUnit &unit, short int *xdp, short int *ydp);
 /// Return path length to unit 'dst'.
 extern int UnitReachable(const CUnit &src, const CUnit &dst, int range);
 /// Return path length to unit 'dst' or error code.
-extern int CalcPathToUnit(const CUnit &src, const CUnit &dst, 
+extern int CalcPathToUnit(const CUnit &src, const CUnit &dst,
 						  const int minrange, const int range);
 /// Can the unit 'src' reach the place x,y
 extern int PlaceReachable(const CUnit &src, const Vec2i &pos, int w, int h,

--- a/src/include/pathfinder.h
+++ b/src/include/pathfinder.h
@@ -218,8 +218,11 @@ extern void FreePathfinder();
 
 /// Returns the next element of the path
 extern int NextPathElement(CUnit &unit, short int *xdp, short int *ydp);
-/// Return distance to unit.
-extern int UnitReachable(const CUnit &unit, const CUnit &dst, int range);
+/// Return path length to unit 'dst'.
+extern int UnitReachable(const CUnit &src, const CUnit &dst, int range);
+/// Return path length to unit 'dst' or error code.
+extern int CalcPathToUnit(const CUnit &src, const CUnit &dst, 
+						  const int minrange, const int range);
 /// Can the unit 'src' reach the place x,y
 extern int PlaceReachable(const CUnit &src, const Vec2i &pos, int w, int h,
 						  int minrange, int maxrange);

--- a/src/include/pathfinder.h
+++ b/src/include/pathfinder.h
@@ -199,8 +199,6 @@ extern int AStarMovingUnitCrossingCost;
 extern bool AStarKnowUnseenTerrain;
 /// Cost of using a square we haven't seen before.
 extern int AStarUnknownTerrainCost;
-/// Used to temporary make enemy units unpassable (needs for correct path lenght calculating for automatic targeting alorithm)
-extern bool AStarFixedEnemyUnitsUnpassable;
 
 //
 //  Convert heading into direction.

--- a/src/include/pathfinder.h
+++ b/src/include/pathfinder.h
@@ -199,6 +199,8 @@ extern int AStarMovingUnitCrossingCost;
 extern bool AStarKnowUnseenTerrain;
 /// Cost of using a square we haven't seen before.
 extern int AStarUnknownTerrainCost;
+/// Used to temporary make enemy units unpassable (needs for correct path lenght calculating for automatic targeting alorithm)
+extern bool AStarFixedEnemyUnitsUnpassable;
 
 //
 //  Convert heading into direction.
@@ -221,7 +223,7 @@ extern int NextPathElement(CUnit &unit, short int *xdp, short int *ydp);
 /// Return path length to unit 'dst'.
 extern int UnitReachable(const CUnit &src, const CUnit &dst, int range);
 /// Return path length to unit 'dst' or error code.
-extern int CalcPathToUnit(const CUnit &src, const CUnit &dst,
+extern int CalcPathLengthToUnit(const CUnit &src, const CUnit &dst,
 						  const int minrange, const int range);
 /// Can the unit 'src' reach the place x,y
 extern int PlaceReachable(const CUnit &src, const Vec2i &pos, int w, int h,
@@ -239,6 +241,9 @@ extern int GetAStarMovingUnitCrossingCost();
 
 extern void SetAStarUnknownTerrainCost(int cost);
 extern int GetAStarUnknownTerrainCost();
+
+extern void SetAStarFixedEnemyUnitsUnpassable(const bool value);
+extern bool GetAStarFixedEnemyUnitsUnpassable();
 
 extern void PathfinderCclRegister();
 

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -411,6 +411,7 @@ unsigned    ByPlayer : PlayerMax;   /// Track unit seen by player
 
 	unsigned int Wait;          /// action counter
 	int Threshold;              /// The counter while ai unit couldn't change target.
+	int UnderAttack;			/// The counter while small ai can ignore non aggressive targets if searching attacker.
 
 	struct _unit_anim_ {
 		const CAnimation *Anim;      /// Anim

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -592,6 +592,8 @@ extern bool InAttackRange(const CUnit &unit, const CUnit &target);
 extern bool InAttackRange(const CUnit &unit, const Vec2i &tilePos);
 /// Return new position for 'unit' to retreat from 'src'
 extern Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange);
+/// Return new position for 'unit' to retreat from 'srcPos'
+extern Vec2i PosToRetreat(const CUnit &unit, const Vec2i &srcPos, const int minRange);
 
 
 /// Hit unit with damage, if destroyed give attacker the points

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -76,14 +76,29 @@ typedef COrder *COrderPtr;
 
 /*
 ** Configuration of the small (unit) AI.
+** sPPP PPdd dddd dddd 0000 0000 0hhh hhhh 
+** s... .ppp pppp p... .... .... .... ....
+** s... ...I .... .... iiii i... .... ....                             
+** s... .... .... c... .... .... .... ....
 */
-#define PRIORITY_FACTOR   0x00080000
-#define HEALTH_FACTOR     0x00000001
-#define DISTANCE_FACTOR   0x00010000
-#define INRANGE_FACTOR    0x00008000
-#define INRANGE_BONUS     0x01000000
-#define CANATTACK_BONUS   0x00080000
-#define AIPRIORITY_BONUS  0x04000000
+#define PRIORITY_FACTOR   0x00080000   /// p
+#define HEALTH_FACTOR     0x00000001   /// h (0..100)%
+#define DISTANCE_FACTOR   0x00010000   /// d (0..1023)
+#define INRANGE_FACTOR    0x00008000   /// i (0..31)
+#define INRANGE_BONUS     0x01000000   /// I
+#define CANATTACK_BONUS   0x00080000   /// c
+#define AIPRIORITY_BONUS  0x04000000   /// P (0..31)
+
+/*
+** Same for alternate (simplified) implementation of the small (unit) AI.
+** sA00 PPPP  Pppp pppp  pddd dddd  dhhh hhhh
+*/
+#define ALTERNATE_AT		  /* Activate alternative auto targeting algorithm */
+#define AT_THREAT_FACTOR      0x40000000 /// A
+#define AT_PRIORITY_OFFSET    15         /// p (0..255)
+#define AT_AIPRIORITY_OFFSET  23         /// P (0..31) 
+#define AT_DISTANCE_OFFSET    7          /// d (0..255) TODO: may be to make range smaller
+#define AT_PRIORITY_MASK_HI   0xFFFF8000 /// Mask for checking only priority (without distance part)
 
 
 /// Called whenever the selected unit was updated
@@ -433,7 +448,7 @@ public:
 		ShowAttackRange(false), ShowMessages(true), BigScreen(false),
 		PauseOnLeave(true), AiExplores(true), GrayscaleIcons(false),
 		IconsShift(false), StereoSound(true), MineNotifications(false),
-		DeselectInMine(false), NoStatusLineTooltips(false),
+		DeselectInMine(false), NoStatusLineTooltips(false), SimplifiedAutoTargeting(true),
 		IconFrameG(NULL), PressedIconFrameG(NULL),
 		ShowOrders(0), ShowNameDelay(0), ShowNameTime(0), AutosaveMinutes(5) {};
 
@@ -450,6 +465,9 @@ public:
 	bool MineNotifications;    /// Show mine is running low/depleted messages
 	bool DeselectInMine;       /// Deselect peasants in mines
 	bool NoStatusLineTooltips; /// Don't show messages on status line
+
+/// FIXME: 	Doesn't change in menu
+	bool SimplifiedAutoTargeting; /// Use alternate target choosing algorithm for auto attack mode (idle, attack-move, patrol, etc.)
 
 	int ShowOrders;			/// How many second show orders of unit on map.
 	int ShowNameDelay;		/// How many cycles need to wait until unit's name popup will appear.
@@ -566,6 +584,14 @@ extern void LetUnitDie(CUnit &unit, bool suicide = false);
 extern void DestroyAllInside(CUnit &source);
 /// Calculate some value to measure the unit's priority for AI
 extern int ThreatCalculate(const CUnit &unit, const CUnit &dest);
+extern int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest);
+
+/// Is target within reaction range of this unit?
+extern bool InReactRange(const CUnit &unit, const CUnit &target);
+/// Is target within attack range of this unit?
+extern bool InAttackRange(const CUnit &unit, const CUnit &target);
+
+
 /// Hit unit with damage, if destroyed give attacker the points
 extern void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile = NULL);
 

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -590,6 +590,8 @@ extern int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *con
 extern bool InReactRange(const CUnit &unit, const CUnit &target);
 /// Is target within attack range of this unit?
 extern bool InAttackRange(const CUnit &unit, const CUnit &target);
+/// Is tile within attack range of this unit?
+extern bool InAttackRange(const CUnit &unit, const Vec2i &tilePos);
 
 
 /// Hit unit with damage, if destroyed give attacker the points

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -91,15 +91,15 @@ typedef COrder *COrderPtr;
 
 /*
 ** Same for alternate (simplified) implementation of the small (unit) AI.
-** FIXME: may be we have to swap P & p?
-** sA00 PPPP  Pppp pppp  pddd dddd  dhhh hhhh
+** sAT0 0000  0ppp pppp  pddd dddd  dhhh hhhh
 */
-#define AT_THREAT_FACTOR      0x40000000 /// A
-#define AT_AIPRIORITY_OFFSET  23         /// P (0..31) 
+#define AT_ATTACKED_BY_FACTOR 0x40000000 /// A (attacker is under attack by target)
+#define AT_THREAT_FACTOR      0x20000000 /// T
 #define AT_PRIORITY_OFFSET    15         /// p (0..255)
-#define AT_DISTANCE_OFFSET    7          /// d (0..255) TODO: may be to make range smaller
+#define AT_DISTANCE_OFFSET    7          /// d (0..255) 
 #define AT_PRIORITY_MASK_HI   0xFFFF8000 /// Mask for checking only priority (without distance part)
 
+#define AT_FARAWAY_REDUCE_OFFSET 14      /// Priority reduce offset for far away targets (AT_THREAT_FACTOR must be preserved if present)
 
 /// Called whenever the selected unit was updated
 extern void SelectedUnitChanged();

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -590,6 +590,8 @@ extern bool InReactRange(const CUnit &unit, const CUnit &target);
 extern bool InAttackRange(const CUnit &unit, const CUnit &target);
 /// Is tile within attack range of this unit?
 extern bool InAttackRange(const CUnit &unit, const Vec2i &tilePos);
+/// Return new position for 'unit' to retreat from 'src'
+extern Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange);
 
 
 /// Hit unit with damage, if destroyed give attacker the points

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -91,12 +91,12 @@ typedef COrder *COrderPtr;
 
 /*
 ** Same for alternate (simplified) implementation of the small (unit) AI.
+** FIXME: may be we have to swap P & p?
 ** sA00 PPPP  Pppp pppp  pddd dddd  dhhh hhhh
 */
-#define ALTERNATE_AT		  /* Activate alternative auto targeting algorithm */
 #define AT_THREAT_FACTOR      0x40000000 /// A
-#define AT_PRIORITY_OFFSET    15         /// p (0..255)
 #define AT_AIPRIORITY_OFFSET  23         /// P (0..31) 
+#define AT_PRIORITY_OFFSET    15         /// p (0..255)
 #define AT_DISTANCE_OFFSET    7          /// d (0..255) TODO: may be to make range smaller
 #define AT_PRIORITY_MASK_HI   0xFFFF8000 /// Mask for checking only priority (without distance part)
 

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -76,9 +76,9 @@ typedef COrder *COrderPtr;
 
 /*
 ** Configuration of the small (unit) AI.
-** sPPP PPdd dddd dddd 0000 0000 0hhh hhhh 
+** sPPP PPdd dddd dddd 0000 0000 0hhh hhhh
 ** s... .ppp pppp p... .... .... .... ....
-** s... ...I .... .... iiii i... .... ....                             
+** s... ...I .... .... iiii i... .... ....
 ** s... .... .... c... .... .... .... ....
 */
 #define PRIORITY_FACTOR   0x00080000   /// p
@@ -466,7 +466,7 @@ public:
 	bool DeselectInMine;       /// Deselect peasants in mines
 	bool NoStatusLineTooltips; /// Don't show messages on status line
 	bool SimplifiedAutoTargeting; /// Use alternate target choosing algorithm for auto attack mode (idle, attack-move, patrol, etc.)
-		 
+
 	int ShowOrders;			/// How many second show orders of unit on map.
 	int ShowNameDelay;		/// How many cycles need to wait until unit's name popup will appear.
 	int ShowNameTime;		/// How many cycles need to show unit's name popup.

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -448,7 +448,7 @@ public:
 		ShowAttackRange(false), ShowMessages(true), BigScreen(false),
 		PauseOnLeave(true), AiExplores(true), GrayscaleIcons(false),
 		IconsShift(false), StereoSound(true), MineNotifications(false),
-		DeselectInMine(false), NoStatusLineTooltips(false), SimplifiedAutoTargeting(true),
+		DeselectInMine(false), NoStatusLineTooltips(false), SimplifiedAutoTargeting(false),
 		IconFrameG(NULL), PressedIconFrameG(NULL),
 		ShowOrders(0), ShowNameDelay(0), ShowNameTime(0), AutosaveMinutes(5) {};
 
@@ -465,10 +465,8 @@ public:
 	bool MineNotifications;    /// Show mine is running low/depleted messages
 	bool DeselectInMine;       /// Deselect peasants in mines
 	bool NoStatusLineTooltips; /// Don't show messages on status line
-
-/// FIXME: 	Doesn't change in menu
 	bool SimplifiedAutoTargeting; /// Use alternate target choosing algorithm for auto attack mode (idle, attack-move, patrol, etc.)
-
+		 
 	int ShowOrders;			/// How many second show orders of unit on map.
 	int ShowNameDelay;		/// How many cycles need to wait until unit's name popup will appear.
 	int ShowNameTime;		/// How many cycles need to show unit's name popup.

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -590,10 +590,10 @@ extern bool InReactRange(const CUnit &unit, const CUnit &target);
 extern bool InAttackRange(const CUnit &unit, const CUnit &target);
 /// Is tile within attack range of this unit?
 extern bool InAttackRange(const CUnit &unit, const Vec2i &tilePos);
-/// Return new position for 'unit' to retreat from 'src'
-extern Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange);
-/// Return new position for 'unit' to retreat from 'srcPos'
-extern Vec2i PosToRetreat(const CUnit &unit, const Vec2i &srcPos, const int minRange);
+/// Return randomly selected position in direction (to/from) dirUnit from srcPos 
+extern Vec2i GetRndPosInDirection(const Vec2i &srcPos, const CUnit &dirUnit, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev = 3);
+/// Return randomly selected position in direction (to/from) dirPos from srcPos 
+extern Vec2i GetRndPosInDirection(const Vec2i &srcPos, const Vec2i &dirPos, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev = 3);
 
 
 /// Hit unit with damage, if destroyed give attacker the points

--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -171,6 +171,7 @@ enum {
 	ORGANIC_INDEX,					/// Organic unit (used for death coil spell)
 	SIDEATTACK_INDEX,
 	SKIRMISHER_INDEX,
+	ALWAYSTHREAT_INDEX,				/// Unit always considered as threat for auto targeting algorihm, useful for unit without main attack ability, but which can cast spells (f.e. defiler in SC:BW)
 	NOFRIENDLYFIRE_INDEX,           /// Unit accepts friendly fire for splash attacks
 	NBARALREADYDEFINED
 };

--- a/src/pathfinder/astar.cpp
+++ b/src/pathfinder/astar.cpp
@@ -101,6 +101,7 @@ int AStarFixedUnitCrossingCost;// = MaxMapWidth * MaxMapHeight;
 int AStarMovingUnitCrossingCost = 5;
 bool AStarKnowUnseenTerrain = false;
 int AStarUnknownTerrainCost = 2;
+bool AStarFixedEnemyUnitsUnpassable = false;
 
 static int AStarMapWidth;
 static int AStarMapHeight;
@@ -542,6 +543,9 @@ static int CostMoveToCallBack_Default(unsigned int index, const CUnit &unit)
 				} else {
 					// for non moving unit Always Fail unless goal is unit, or unit can attack the target
 					if (&unit != goal) {
+						if (GetAStarFixedEnemyUnitsUnpassable() == true) {
+							return -1;
+						}
 						if (goal->Player->IsEnemy(unit) && unit.IsAgressive() && CanTarget(*unit.Type, *goal->Type)
 							&& goal->Variable[UNHOLYARMOR_INDEX].Value == 0 && goal->IsVisibleAsGoal(*unit.Player)) {
 								cost += 2 * AStarMovingUnitCrossingCost;
@@ -1164,4 +1168,13 @@ int GetAStarUnknownTerrainCost()
 	return AStarUnknownTerrainCost;
 }
 
+void SetAStarFixedEnemyUnitsUnpassable(const bool value)
+{
+	AStarFixedEnemyUnitsUnpassable = value;
+}
+
+bool GetAStarFixedEnemyUnitsUnpassable()
+{
+	return AStarFixedEnemyUnitsUnpassable;
+}
 //@}

--- a/src/pathfinder/astar.cpp
+++ b/src/pathfinder/astar.cpp
@@ -101,7 +101,8 @@ int AStarFixedUnitCrossingCost;// = MaxMapWidth * MaxMapHeight;
 int AStarMovingUnitCrossingCost = 5;
 bool AStarKnowUnseenTerrain = false;
 int AStarUnknownTerrainCost = 2;
-bool AStarFixedEnemyUnitsUnpassable = false;
+/// Used to temporary make enemy units unpassable (needs for correct path lenght calculating for automatic targeting alorithm)
+static bool AStarFixedEnemyUnitsUnpassable = false;
 
 static int AStarMapWidth;
 static int AStarMapHeight;

--- a/src/pathfinder/pathfinder.cpp
+++ b/src/pathfinder/pathfinder.cpp
@@ -245,13 +245,15 @@ int UnitReachable(const CUnit &src, const CUnit &dst, int range)
 **  @return       path length to dst or error code
 */
 
-int CalcPathToUnit(const CUnit &src, const CUnit &dst, const int minrange, const int range)
+int CalcPathLengthToUnit(const CUnit &src, const CUnit &dst, const int minrange, const int range)
 {
+	SetAStarFixedEnemyUnitsUnpassable(true); /// change Path Finder setting to don't count tiles with enemy units as passable
 	int length = AStarFindPath(src.tilePos, dst.tilePos,
 							   dst.Type->TileWidth, dst.Type->TileHeight,
 							   src.Type->TileWidth, src.Type->TileHeight,
 							   minrange, range,
 							   NULL, 0, src);
+   SetAStarFixedEnemyUnitsUnpassable(false); /// restore Path Finder setting
 	switch (length) {
 		case PF_FAILED:
 		case PF_UNREACHABLE:

--- a/src/pathfinder/pathfinder.cpp
+++ b/src/pathfinder/pathfinder.cpp
@@ -185,10 +185,11 @@ void FreePathfinder()
 */
 int PlaceReachable(const CUnit &src, const Vec2i &goalPos, int w, int h, int minrange, int range)
 {
+	SetAStarFixedEnemyUnitsUnpassable(true); /// change Path Finder setting to don't count tiles with enemy units as passable
 	int i = AStarFindPath(src.tilePos, goalPos, w, h,
 						  src.Type->TileWidth, src.Type->TileHeight,
 						  minrange, range, NULL, 0, src);
-
+	SetAStarFixedEnemyUnitsUnpassable(false); /// restore Path Finder setting
 	switch (i) {
 		case PF_FAILED:
 		case PF_UNREACHABLE:
@@ -253,7 +254,7 @@ int CalcPathLengthToUnit(const CUnit &src, const CUnit &dst, const int minrange,
 							   src.Type->TileWidth, src.Type->TileHeight,
 							   minrange, range,
 							   NULL, 0, src);
-   SetAStarFixedEnemyUnitsUnpassable(false); /// restore Path Finder setting
+	SetAStarFixedEnemyUnitsUnpassable(false); /// restore Path Finder setting
 	switch (length) {
 		case PF_FAILED:
 		case PF_UNREACHABLE:

--- a/src/pathfinder/pathfinder.cpp
+++ b/src/pathfinder/pathfinder.cpp
@@ -234,6 +234,37 @@ int UnitReachable(const CUnit &src, const CUnit &dst, int range)
 	return depth;
 }
 
+/**
+**  Calc path length for the unit 'src' to reach the unit 'dst'.
+**
+**  @param src     	 Unit for the path.
+**  @param dst    	 Unit to be reached.
+**  @param minrange  min range to the tile
+**  @param range     Range to the tile.
+**
+**  @return       path length to dst or error code
+*/
+
+int CalcPathToUnit(const CUnit &src, const CUnit &dst, const int minrange, const int range)
+{
+	int length = AStarFindPath(src.tilePos, dst.tilePos, 
+							   dst.Type->TileWidth, dst.Type->TileHeight,
+							   src.Type->TileWidth, src.Type->TileHeight,
+							   minrange, range, 
+							   NULL, 0, src);
+	switch (length)
+	{
+		case PF_FAILED:
+		case PF_UNREACHABLE:
+		case PF_WAIT:
+			return -1;
+			break;
+		case PF_REACHED:
+			return 0;
+	}
+	return length;
+}
+
 /*----------------------------------------------------------------------------
 --  REAL PATH-FINDER
 ----------------------------------------------------------------------------*/

--- a/src/pathfinder/pathfinder.cpp
+++ b/src/pathfinder/pathfinder.cpp
@@ -247,13 +247,12 @@ int UnitReachable(const CUnit &src, const CUnit &dst, int range)
 
 int CalcPathToUnit(const CUnit &src, const CUnit &dst, const int minrange, const int range)
 {
-	int length = AStarFindPath(src.tilePos, dst.tilePos, 
+	int length = AStarFindPath(src.tilePos, dst.tilePos,
 							   dst.Type->TileWidth, dst.Type->TileHeight,
 							   src.Type->TileWidth, src.Type->TileHeight,
-							   minrange, range, 
+							   minrange, range,
 							   NULL, 0, src);
-	switch (length)
-	{
+	switch (length) {
 		case PF_FAILED:
 		case PF_UNREACHABLE:
 		case PF_WAIT:

--- a/src/tolua/unit.pkg
+++ b/src/tolua/unit.pkg
@@ -31,6 +31,7 @@ class CPreference
 	bool MineNotifications;
 	bool DeselectInMine;
 	bool NoStatusLineTooltips;
+	bool SimplifiedAutoTargeting;
 
 	unsigned int ShowOrders;
 	unsigned int ShowNameDelay;

--- a/src/unit/script_unittype.cpp
+++ b/src/unit/script_unittype.cpp
@@ -94,6 +94,7 @@ static const char NORANDOMPLACING_KEY[] = "NoRandomPlacing";
 static const char ORGANIC_KEY[] = "organic";
 static const char SIDEATTACK_KEY[] = "SideAttack";
 static const char SKIRMISHER_KEY[] = "Skirmisher";
+static const char ALWAYSTHREAT_KEY[] = "AlwaysThreat";
 static const char NOFRIENDLYFIRE_KEY[] = "NoFriendlyFire";
 
 // names of the variable.
@@ -153,7 +154,7 @@ CUnitTypeVar::CBoolKeys::CBoolKeys()
 							   BUILDERLOST_KEY, CANHARVEST_KEY, HARVESTER_KEY, SELECTABLEBYRECTANGLE_KEY,
 							   ISNOTSELECTABLE_KEY, DECORATION_KEY, INDESTRUCTIBLE_KEY, TELEPORTER_KEY, SHIELDPIERCE_KEY,
 							   SAVECARGO_KEY, NONSOLID_KEY, WALL_KEY, NORANDOMPLACING_KEY, ORGANIC_KEY, SIDEATTACK_KEY, SKIRMISHER_KEY,
-							   NOFRIENDLYFIRE_KEY
+							   ALWAYSTHREAT_KEY, NOFRIENDLYFIRE_KEY
 							  };
 
 	for (int i = 0; i < NBARALREADYDEFINED; ++i) {

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2542,12 +2542,10 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 	int priority = 0;
 
 	// is Threat?
-	/// Check if target attacks us
-	if (dest->CurrentAction() == (UnitActionAttack || UnitActionStandGround || UnitActionSpellCast)
-		&& dest->CurrentOrder()->GetGoal() == attacker) {
+	/// Check if target attacks us 
+	if (dest->CurrentOrder()->HasGoal() && dest->CurrentOrder()->GetGoal() == attacker) {
 		priority |= AT_ATTACKED_BY_FACTOR;
 	}
-
 	// FIXME: Add alwaysThreat property to CUnitType
 	// Unit can attack back.
 	if (CanTarget(dtype, type)) {
@@ -2557,7 +2555,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 	// To reduce units roaming when a lot of them fight in small areas
 	// we do full priority calculations only for easy reachable targets, or for targets which attacks this unit.
 	// For other targets we dramaticaly reduce priority and calc only threat factor, distance and health
-	const bool isFarAwayTarget = (!(priority &= AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > 1.5 * reactionRange)) ? true : false;
+	const bool isFarAwayTarget = (!(priority & AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > 1.5 * reactionRange)) ? true : false;
 
 	if (isFarAwayTarget || distance < minAttackRange) {
 		priority >>= AT_FARAWAY_REDUCE_OFFSET; // save AT_THREAT_FACTOR if present

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2534,6 +2534,7 @@ DebugPrint("Target: %s[%d], Distance: %d, PathLength: %d \n" _C_ dest->Type->Ide
 	int priority = 0;
 
 	// is Threat?
+	// FIXME: Add alwaysThreat property to CUnitType
 	// Unit can attack back.
 	if (CanTarget(dtype, type)) {
 		priority |= AT_THREAT_FACTOR;
@@ -2607,6 +2608,26 @@ bool InAttackRange(const CUnit &unit, const CUnit &target)
 	return (minRange <= distance && distance <= range)
 			&& (!GameSettings.Inside 
 				|| CheckObstaclesBetweenTiles(unit.tilePos, target.tilePos, MapFieldRocks | MapFieldForest));
+}
+
+/**
+**  Returns true, if tile is in attack range of the unit and there is no obstacles between them (when inside caves)
+**  @todo: Do we have to check range from unit.Container pos if unit is bunkered or in transport?
+**   
+**  @param unit    Unit to check for.
+**	@param pos     Checked position.
+**
+**  @return       True if in attack range, false otherwise.
+*/
+bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
+{
+	const int range 	= unit.Stats->Variables[ATTACKRANGE_INDEX].Max;
+	const int minRange 	= unit.Type->MinAttackRange;
+	const int distance 	= unit.MapDistanceTo(tilePos);	
+	
+	return (minRange <= distance && distance <= range)
+			&& (!GameSettings.Inside 
+				|| CheckObstaclesBetweenTiles(unit.tilePos, tilePos, MapFieldRocks | MapFieldForest));
 }
 
 static void HitUnit_LastAttack(const CUnit *attacker, CUnit &target)

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2542,13 +2542,13 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 	int priority = 0;
 
 	// is Threat?
-	/// Check if target attacks us 
+	/// Check if target attacks us (or has us as goal for any action)
 	if (dest->CurrentOrder()->HasGoal() && dest->CurrentOrder()->GetGoal() == attacker) {
 		priority |= AT_ATTACKED_BY_FACTOR;
 	}
 	// FIXME: Add alwaysThreat property to CUnitType
 	// Unit can attack back.
-	if (CanTarget(dtype, type)) {
+	if (CanTarget(dtype, type) || dtype.BoolFlag[ALWAYSTHREAT_INDEX].value) {
 		priority |= AT_THREAT_FACTOR;
 	}
 

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2445,6 +2445,12 @@ void DestroyAllInside(CUnit &source)
 
 int ThreatCalculate(const CUnit &unit, const CUnit &dest)
 {
+
+	if (Preference.SimplifiedAutoTargeting) {
+		// Original algorithm return smaler values for better targets
+		return -TargetPriorityCalculate(&unit, &dest);
+	}
+
 	const CUnitType &type = *unit.Type;
 	const CUnitType &dtype = *dest.Type;
 	int cost = 0;

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -3027,6 +3027,7 @@ void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile)
 		&& !(target.BoardCount && target.Type->BoolFlag[ATTACKFROMTRANSPORTER_INDEX].value == true)) {
 
 		HitUnit_RunAway(target, *attacker);
+		return;
 	}
 
 	const int threshold = 30;

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2874,9 +2874,7 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 		&& attacker.Player != target.Player && target.IsEnemy(attacker)
 		&& CanTarget(*target.Type, *attacker.Type))	{
 		
-		Vec2i posToAttack = Vec2i(-1, -1);
 		const unsigned char targetCurrAction = target.CurrentAction();
-		
 		if (targetCurrAction == UnitActionAttack) {
 			COrder_Attack &order = dynamic_cast<COrder_Attack &>(*target.CurrentOrder());
 			if (order.IsAutoTargeting() || target.Player->AiEnabled) {
@@ -2896,11 +2894,7 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 		if (target.UnderAttack) {
 			return;
 		}
-		if (attacker.IsVisibleAsGoal(*target.Player)) {
-			posToAttack = attacker.tilePos;
-		} else {
-			posToAttack = GetRndPosInDirection(target.tilePos, attacker.tilePos, false, target.Type->ReactRangeComputer, 2);
-		}
+	
 		switch (targetCurrAction)
 		{
 		case UnitActionStandGround:
@@ -2914,14 +2908,20 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 		case UnitActionStill:
 		case UnitActionDefend:
 		case UnitActionPatrol:
+		
 			COrder *savedOrder = NULL;
 			if (targetCurrAction == UnitActionStill || targetCurrAction == UnitActionStandGround) {
 				savedOrder = COrder::NewActionAttack(target, target.tilePos);
 			} else if (target.CanStoreOrder(target.CurrentOrder())) {
 				savedOrder = target.CurrentOrder()->Clone();
 			}
+
 			target.UnderAttack = underAttack; /// allow target to ignore non aggressive targets while searching attacker
+			const Vec2i posToAttack = (attacker.IsVisibleAsGoal(*target.Player)) 
+									? attacker.tilePos 
+									: GetRndPosInDirection(target.tilePos, attacker.tilePos, false, target.Type->ReactRangeComputer, 2);
 			CommandAttack(target, posToAttack, NULL, FlushCommands);
+
 			if (savedOrder != NULL) {
 				target.SavedOrder = savedOrder;
 			}

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2866,8 +2866,7 @@ static void HitUnit_RunAway(CUnit &target, const CUnit &attacker)
 
 static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 {
-	const int underAttack = 240;
-	DebugPrint("UnderAttack counter: %d\n" _C_ target.UnderAttack);
+	const int underAttack = 128;
 	if (&attacker != target.CurrentOrder()->GetGoal()
 		&& attacker.Player != target.Player && target.IsEnemy(attacker)
 		&& CanTarget(*target.Type, *attacker.Type))	{
@@ -2883,7 +2882,7 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 				} 
 				if (order.HasGoal() && order.GetGoal()->IsAgressive()) {
 					return;
-				} 
+				}
 			} else {
 				return;
 			}

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -569,8 +569,8 @@ bool CUnit::IsAlive() const
 int CUnit::GetDrawLevel() const
 {
 	return ((Type->CorpseType && CurrentAction() == UnitActionDie) ?
-		Type->CorpseType->DrawLevel :
-	((CurrentAction() == UnitActionDie) ? Type->DrawLevel - 10 : Type->DrawLevel));;
+			Type->CorpseType->DrawLevel :
+			((CurrentAction() == UnitActionDie) ? Type->DrawLevel - 10 : Type->DrawLevel));;
 }
 
 /**
@@ -603,7 +603,7 @@ void CUnit::Init(const CUnitType &type)
 	}
 
 	memset(IndividualUpgrades, 0, sizeof(IndividualUpgrades));
-	
+
 	// Set a heading for the unit if it Handles Directions
 	// Don't set a building heading, as only 1 construction direction
 	//   is allowed.
@@ -1797,7 +1797,7 @@ void CUnit::ChangeOwner(CPlayer &newplayer)
 			ApplyIndividualUpgradeModifier(*this, UpgradeModifiers[z]); //apply the upgrade to this unit only
 		}
 	}
-	
+
 	UpdateForNewUnit(*this, 1);
 }
 
@@ -2512,22 +2512,21 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 	if (dtype.BoolFlag[INDESTRUCTIBLE_INDEX].value || dest->Variable[UNHOLYARMOR_INDEX].Value) {
 		return INT_MIN;
 	}
-	
+
 	const int attackRange 	 = attacker->Stats->Variables[ATTACKRANGE_INDEX].Max;
 	const int minAttackRange = attacker->Type->MinAttackRange;
 	const int pathLength 	 = CalcPathToUnit(*attacker, *dest, minAttackRange, attackRange);
-		  int distance		 = attacker->MapDistanceTo(*dest);	
+	int distance		 	 = attacker->MapDistanceTo(*dest);
 
-	const int reactionRange  = (player.Type == PlayerPerson) ? type.ReactRangePerson 
-															 : type.ReactRangeComputer;
+	const int reactionRange  = (player.Type == PlayerPerson) ? type.ReactRangePerson : type.ReactRangeComputer;
 
 
 	if (!InAttackRange(*attacker, *dest)
-		&& ((distance > minAttackRange && pathLength < 0) 
+		&& ((distance > minAttackRange && pathLength < 0)
 			|| attacker->CanMove() == false)) {
-			return INT_MIN;
-	}	
-	
+		return INT_MIN;
+	}
+
 
 	// Attack walls only if we are stuck in them
 	if (dtype.BoolFlag[WALL_INDEX].value && distance > 1) {
@@ -2573,7 +2572,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 		}
 		// AI Priority (0-31)
 		priority |= (ai_priority > 31 ? 31 : (ai_priority < 0 ? 0 : ai_priority)) << AT_AIPRIORITY_OFFSET;
-	} 
+	}
 
 	// Calc distance factor (0-255)
 	priority |= (255 - (pathLength > 255 || pathLength < 0 ? 255 : pathLength)) << AT_DISTANCE_OFFSET;
@@ -2597,15 +2596,15 @@ bool InReactRange(const CUnit &unit, const CUnit &target)
 {
 	const int distance 	= unit.MapDistanceTo(target);
 	const int range 	= (unit.Player->Type == PlayerPerson)
-												? unit.Type->ReactRangePerson 
-												: unit.Type->ReactRangeComputer;
+						  ? unit.Type->ReactRangePerson
+						  : unit.Type->ReactRangeComputer;
 	return distance <= range;
 }
 
 /**
 **  Returns true, if target is in attack range of the unit and there is no obstacles between them (when inside caves)
 **  @todo: Do we have to check range from unit.Container pos if unit is bunkered or in transport?
-**   
+**
 **  @param unit    Unit to check for.
 **  @param target  Checked target.
 **
@@ -2615,17 +2614,17 @@ bool InAttackRange(const CUnit &unit, const CUnit &target)
 {
 	const int range 	= unit.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	const int minRange 	= unit.Type->MinAttackRange;
-	const int distance 	= unit.MapDistanceTo(target);	
-	
+	const int distance 	= unit.MapDistanceTo(target);
+
 	return (minRange <= distance && distance <= range)
-			&& (!GameSettings.Inside 
-				|| CheckObstaclesBetweenTiles(unit.tilePos, target.tilePos, MapFieldRocks | MapFieldForest));
+		   && (!GameSettings.Inside
+			   || CheckObstaclesBetweenTiles(unit.tilePos, target.tilePos, MapFieldRocks | MapFieldForest));
 }
 
 /**
 **  Returns true, if tile is in attack range of the unit and there is no obstacles between them (when inside caves)
 **  @todo: Do we have to check range from unit.Container pos if unit is bunkered or in transport?
-**   
+**
 **  @param unit    Unit to check for.
 **  @param pos     Checked position.
 **
@@ -2635,11 +2634,11 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 {
 	const int range 	= unit.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	const int minRange 	= unit.Type->MinAttackRange;
-	const int distance 	= unit.MapDistanceTo(tilePos);	
-	
+	const int distance 	= unit.MapDistanceTo(tilePos);
+
 	return (minRange <= distance && distance <= range)
-			&& (!GameSettings.Inside 
-				|| CheckObstaclesBetweenTiles(unit.tilePos, tilePos, MapFieldRocks | MapFieldForest));
+		   && (!GameSettings.Inside
+			   || CheckObstaclesBetweenTiles(unit.tilePos, tilePos, MapFieldRocks | MapFieldForest));
 }
 
 
@@ -2849,16 +2848,16 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 
 	if (target.Player->AiEnabled == false) {
 		return;
-/*		
-		if (target.CurrentAction() == UnitActionAttack) {
-			COrder_Attack &order = dynamic_cast<COrder_Attack &>(*target.CurrentOrder());
-			if (order.IsWeakTargetSelected() == false) {
-				return;
-			}
-		} else {
-			return;
-		}
-*/
+		/*
+				if (target.CurrentAction() == UnitActionAttack) {
+					COrder_Attack &order = dynamic_cast<COrder_Attack &>(*target.CurrentOrder());
+					if (order.IsWeakTargetSelected() == false) {
+						return;
+					}
+				} else {
+					return;
+				}
+		*/
 	}
 	if (target.CanStoreOrder(target.CurrentOrder())) {
 		savedOrder = target.CurrentOrder()->Clone();
@@ -3309,11 +3308,11 @@ bool CUnit::IsAttackRanged(CUnit *goal, const Vec2i &goalPos)
 	if (this->Variable[ATTACKRANGE_INDEX].Value <= 1) { //always return false if the units attack range is 1 or lower
 		return false;
 	}
-	
+
 	if (this->Container) { //if the unit is inside a container, the attack will always be ranged
 		return true;
 	}
-	
+
 	if (
 		goal
 		&& goal->IsAliveOnMap()
@@ -3325,11 +3324,11 @@ bool CUnit::IsAttackRanged(CUnit *goal, const Vec2i &goalPos)
 	) {
 		return true;
 	}
-	
+
 	if (!goal && Map.Info.IsPointOnMap(goalPos) && this->MapDistanceTo(goalPos) > 1) {
 		return true;
 	}
-	
+
 	return false;
 }
 

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2653,14 +2653,14 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 */
 Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange)
 {
-	Vec2i pos = unit.tilePos - src.tilePos;
+	Vec2i pos = unit.tilePos - (src.tilePos + src.Type->GetHalfTileSize());
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
 
 	if (!d) {
 		d = 1;
 	}
-	pos.x = unit.tilePos.x + (pos.x * (minRange + (SyncRand() & 2))) / d + (2 - (SyncRand() & 4));
-	pos.y = unit.tilePos.y + (pos.y * (minRange + (SyncRand() & 2))) / d + (2 - (SyncRand() & 4));
+	pos.x = unit.tilePos.x + (pos.x * (minRange + (SyncRand() % 3))) / d + (2 - (SyncRand() % 5));
+	pos.y = unit.tilePos.y + (pos.y * (minRange + (SyncRand() % 3))) / d + (2 - (SyncRand() % 5));
 	Map.Clamp(pos);
 	return pos;
 }

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2675,13 +2675,12 @@ Vec2i GetRndPosInDirection(const Vec2i &srcPos, const Vec2i &dirPos, const bool 
 	Vec2i pos = dirPos - srcPos;
 	pos *= dirFrom ? -1 : 1;
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
-
 	if (!d) {
 		d = 1;
 	}
-	const int range = minRange + (SyncRand() % (rangeDev + 1));
-	pos.x = srcPos.x + (pos.x * range) / d + (devRadius - (SyncRand() % (devRadius * 2 + 1)));
-	pos.y = srcPos.y + (pos.y * range) / d + (devRadius - (SyncRand() % (devRadius * 2 + 1)));
+	const int range = minRange + SyncRand(rangeDev + 1);
+	pos.x = srcPos.x + (pos.x * range) / d + (devRadius - SyncRand(devRadius * 2 + 1));
+	pos.y = srcPos.y + (pos.y * range) / d + (devRadius - SyncRand(devRadius * 2 + 1));
 	Map.Clamp(pos);
 	return pos;
 }

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2553,7 +2553,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 	// To reduce units roaming when a lot of them fight in small areas
 	// we do full priority calculations only for easy reachable targets, or for targets which attacks this unit.
 	// For other targets we dramaticaly reduce priority and calc only threat factor, distance and health
-	const bool isFarAwayTarget = (!(priority &= AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > 1.5 * reactionRange) ? true : false;
+	const bool isFarAwayTarget = (!(priority &= AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > 1.5 * reactionRange)) ? true : false;
 
 	if (isFarAwayTarget || distance < minAttackRange) {
 		priority >>= AT_FARAWAY_REDUCE_OFFSET; // save AT_THREAT_FACTOR if present
@@ -2653,7 +2653,7 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 **
 **  @return       	Position
 */
-Vec2i GetRndPosInDirection(const Vec2i &srcPos, const CUnit &dirUnit, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev = 3) {
+Vec2i GetRndPosInDirection(const Vec2i &srcPos, const CUnit &dirUnit, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev)
 {
 	const Vec2i dirPos = dirUnit.tilePos + dirUnit.Type->GetHalfTileSize();
 	return GetRndPosInDirection(srcPos, dirPos, dirFrom, minRange, devRadius, rangeDev);
@@ -2671,7 +2671,8 @@ Vec2i GetRndPosInDirection(const Vec2i &srcPos, const CUnit &dirUnit, const bool
 **
 **  @return       	Position
 */
-Vec2i GetRndPosInDirection(const Vec2i &srcPos, const Vec2i &dirPos, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev = 3) {
+Vec2i GetRndPosInDirection(const Vec2i &srcPos, const Vec2i &dirPos, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev) 
+{
 	Vec2i pos = dirPos - srcPos;
 	pos *= dirFrom ? -1 : 1;
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2498,8 +2498,11 @@ int ThreatCalculate(const CUnit &unit, const CUnit &dest)
 	return cost;
 }
 
-int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest) /*(const CUnit &attacker, const CUnit &dest)*/
+int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest)
 {
+	Assert(attacker != NULL);
+	Assert(dest != NULL);
+
 	const CPlayer &player 	= *attacker->Player;
 	const CUnitType &type 	= *attacker->Type;
 	const CUnitType &dtype 	= *dest->Type;
@@ -2594,6 +2597,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 */
 bool InReactRange(const CUnit &unit, const CUnit &target)
 {
+	Assert(&target != NULL);
 	const int distance 	= unit.MapDistanceTo(target);
 	const int range 	= (unit.Player->Type == PlayerPerson)
 						  ? unit.Type->ReactRangePerson
@@ -2612,6 +2616,7 @@ bool InReactRange(const CUnit &unit, const CUnit &target)
 */
 bool InAttackRange(const CUnit &unit, const CUnit &target)
 {
+	Assert(&target != NULL);
 	const int range 	= unit.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	const int minRange 	= unit.Type->MinAttackRange;
 	const int distance 	= unit.MapDistanceTo(target);
@@ -2632,6 +2637,7 @@ bool InAttackRange(const CUnit &unit, const CUnit &target)
 */
 bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 {
+	Assert(Map.Info.IsPointOnMap(tilePos));
 	const int range 	= unit.Stats->Variables[ATTACKRANGE_INDEX].Max;
 	const int minRange 	= unit.Type->MinAttackRange;
 	const int distance 	= unit.MapDistanceTo(tilePos);
@@ -2656,6 +2662,7 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 */
 Vec2i GetRndPosInDirection(const Vec2i &srcPos, const CUnit &dirUnit, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev)
 {
+	Assert(&dirUnit != NULL);
 	const Vec2i dirPos = dirUnit.tilePos + dirUnit.Type->GetHalfTileSize();
 	return GetRndPosInDirection(srcPos, dirPos, dirFrom, minRange, devRadius, rangeDev);
 }

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2649,11 +2649,26 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 **  @param src      Unit to retreat from.
 **  @param minRange Minimal distance to retreat
 **
-**  @return       	True if in attack range, false otherwise.
+**  @return       	Position to retreat
 */
 Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange)
 {
-	Vec2i pos = unit.tilePos - (src.tilePos + src.Type->GetHalfTileSize());
+	const Vec2i tilePos = src.tilePos + src.Type->GetHalfTileSize();
+	return PosToRetreat(unit, tilePos, minRange);
+}
+
+/**
+**  Return randomly found position for unit in opposite derection to src
+**
+**  @param unit     Unit to move.
+**  @param srcPos   Pos to retreat from.
+**  @param minRange Minimal distance to retreat
+**
+**  @return       	Position to retreat
+*/
+Vec2i PosToRetreat(const CUnit &unit, const Vec2i &srcPos, const int minRange)
+{
+	Vec2i pos = unit.tilePos - srcPos;
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
 
 	if (!d) {

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2555,7 +2555,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 	// To reduce melee units roaming when a lot of them fight in small areas
 	// we do full priority calculations only for easy reachable targets, or for targets which attacks this unit.
 	// For other targets we dramaticaly reduce priority and calc only attacked by/threat factor, distance and health
-	const int maxDistance = attackRange > 1 ? reactionRange : 1.5 * reactionRange;
+	const int maxDistance = attackRange > 1 ? reactionRange : (reactionRange * 3) >> 1 /* x1.5 */;
 	const bool isFarAwayTarget = (!(priority & AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > maxDistance)) ? true : false;
 
 	if (isFarAwayTarget || distance < minAttackRange) {

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2642,6 +2642,21 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 				|| CheckObstaclesBetweenTiles(unit.tilePos, tilePos, MapFieldRocks | MapFieldForest));
 }
 
+
+Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange)
+{
+	Vec2i pos = unit.tilePos - src.tilePos;
+	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
+
+	if (!d) {
+		d = 1;
+	}
+	pos.x = unit.tilePos.x + (pos.x * minRange * (SyncRand() & 2) + 1) / d + (SyncRand() & 2);
+	pos.y = unit.tilePos.y + (pos.y * minRange * (SyncRand() & 2) + 1) / d + (SyncRand() & 2);
+	Map.Clamp(pos);
+	return pos;
+}
+
 static void HitUnit_LastAttack(const CUnit *attacker, CUnit &target)
 {
 	const unsigned long lastattack = target.Attacked;

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2589,7 +2589,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 **  @todo: Do we have to check range from unit.Container pos if unit is bunkered or in transport?
 **
 **  @param unit    Unit to check for.
-**	@param target  Checked target.
+**  @param target  Checked target.
 **
 **  @return       True if within react range, false otherwise.
 */
@@ -2607,7 +2607,7 @@ bool InReactRange(const CUnit &unit, const CUnit &target)
 **  @todo: Do we have to check range from unit.Container pos if unit is bunkered or in transport?
 **   
 **  @param unit    Unit to check for.
-**	@param target  Checked target.
+**  @param target  Checked target.
 **
 **  @return       True if in attack range, false otherwise.
 */
@@ -2627,7 +2627,7 @@ bool InAttackRange(const CUnit &unit, const CUnit &target)
 **  @todo: Do we have to check range from unit.Container pos if unit is bunkered or in transport?
 **   
 **  @param unit    Unit to check for.
-**	@param pos     Checked position.
+**  @param pos     Checked position.
 **
 **  @return       True if in attack range, false otherwise.
 */
@@ -2643,18 +2643,25 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 }
 
 
+/**
+**  Return randomly found position for unit in opposite derection to src
+**
+**  @param unit     Unit to move.
+**  @param src      Unit to retreat from.
+**  @param minRange Minimal distance to retreat
+**
+**  @return       	True if in attack range, false otherwise.
+*/
 Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange)
 {
-	/// FIXME: rewrite to use opposite direction as vector, with random deviations
-
 	Vec2i pos = unit.tilePos - src.tilePos;
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
 
 	if (!d) {
 		d = 1;
 	}
-	pos.x = unit.tilePos.x + (pos.x * minRange * (SyncRand() & 2) + 1) / d + (SyncRand() & 2);
-	pos.y = unit.tilePos.y + (pos.y * minRange * (SyncRand() & 2) + 1) / d + (SyncRand() & 2);
+	pos.x = unit.tilePos.x + (pos.x * (minRange + (SyncRand() & 2))) / d + (2 - (SyncRand() & 4));
+	pos.y = unit.tilePos.y + (pos.y * (minRange + (SyncRand() & 2))) / d + (2 - (SyncRand() & 4));
 	Map.Clamp(pos);
 	return pos;
 }

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2645,6 +2645,8 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 
 Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange)
 {
+	/// FIXME: rewrite to use opposite direction as vector, with random deviations
+
 	Vec2i pos = unit.tilePos - src.tilePos;
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
 

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -3049,11 +3049,14 @@ void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile)
 		return;
 	}
 
-	const int threshold = 30;
-
-	if (target.Threshold && target.CurrentOrder()->HasGoal() && target.CurrentOrder()->GetGoal() == attacker) {
-		target.Threshold = threshold;
-		return;
+	if (Preference.SimplifiedAutoTargeting) {
+		target.Threshold = 0;
+	} else {		
+		const int threshold = 30;
+		if (target.Threshold && target.CurrentOrder()->HasGoal() && target.CurrentOrder()->GetGoal() == attacker) {
+			target.Threshold = threshold;
+			return;
+		}
 	}
 
 	if (target.Threshold == 0 && target.IsAgressive() && target.CanMove() && !target.ReCast) {
@@ -3157,7 +3160,7 @@ int ViewPointDistanceToUnit(const CUnit &dest)
 }
 
 /**
-**  Can the source unit attack the destination unit.
+**  Can the source unit attack the destination unit?
 **
 **  @param source  Unit type pointer of the attacker.
 **  @param dest    Unit type pointer of the target.

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -3030,8 +3030,12 @@ void HitUnit(CUnit *attacker, CUnit &target, int damage, const Missile *missile)
 	}
 
 	// Can't attack run away.
-	if (target.CanMove() && target.CurrentAction() == UnitActionStill
-		&& (!CanTarget(*target.Type, *attacker->Type) || !target.IsAgressive()) 
+	if (target.CanMove() 
+		&& target.CurrentAction() == UnitActionStill
+		&& (!CanTarget(*target.Type, *attacker->Type) 
+			|| !target.IsAgressive() 
+			|| (attacker->Type->BoolFlag[PERMANENTCLOAK_INDEX].value 
+				&& !(attacker->IsVisible(*target.Player) || attacker->IsVisibleOnRadar(*target.Player))))
 		&& !(target.BoardCount && target.Type->BoolFlag[ATTACKFROMTRANSPORTER_INDEX].value == true)) {
 
 		HitUnit_RunAway(target, *attacker);

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2519,7 +2519,7 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 
 	const int attackRange 	 = attacker->Stats->Variables[ATTACKRANGE_INDEX].Max;
 	const int minAttackRange = attacker->Type->MinAttackRange;
-	const int pathLength 	 = CalcPathToUnit(*attacker, *dest, minAttackRange, attackRange);
+	const int pathLength 	 = CalcPathLengthToUnit(*attacker, *dest, minAttackRange, attackRange);
 	int distance		 	 = attacker->MapDistanceTo(*dest);
 
 	const int reactionRange  = (player.Type == PlayerPerson) ? type.ReactRangePerson : type.ReactRangeComputer;

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2671,6 +2671,8 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 	COrder *savedOrder = NULL;
 
 	if (target.Player->AiEnabled == false) {
+		return;
+/*		
 		if (target.CurrentAction() == UnitActionAttack) {
 			COrder_Attack &order = dynamic_cast<COrder_Attack &>(*target.CurrentOrder());
 			if (order.IsWeakTargetSelected() == false) {
@@ -2679,6 +2681,7 @@ static void HitUnit_AttackBack(CUnit &attacker, CUnit &target)
 		} else {
 			return;
 		}
+*/
 	}
 	if (target.CanStoreOrder(target.CurrentOrder())) {
 		savedOrder = target.CurrentOrder()->Clone();

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2552,10 +2552,11 @@ int TargetPriorityCalculate(const CUnit *const attacker, const CUnit *const dest
 		priority |= AT_THREAT_FACTOR;
 	}
 
-	// To reduce units roaming when a lot of them fight in small areas
+	// To reduce melee units roaming when a lot of them fight in small areas
 	// we do full priority calculations only for easy reachable targets, or for targets which attacks this unit.
-	// For other targets we dramaticaly reduce priority and calc only threat factor, distance and health
-	const bool isFarAwayTarget = (!(priority & AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > 1.5 * reactionRange)) ? true : false;
+	// For other targets we dramaticaly reduce priority and calc only attacked by/threat factor, distance and health
+	const int maxDistance = attackRange > 1 ? reactionRange : 1.5 * reactionRange;
+	const bool isFarAwayTarget = (!(priority & AT_ATTACKED_BY_FACTOR) && (pathLength + 1 > maxDistance)) ? true : false;
 
 	if (isFarAwayTarget || distance < minAttackRange) {
 		priority >>= AT_FARAWAY_REDUCE_OFFSET; // save AT_THREAT_FACTOR if present

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -2643,39 +2643,46 @@ bool InAttackRange(const CUnit &unit, const Vec2i &tilePos)
 
 
 /**
-**  Return randomly found position for unit in opposite derection to src
+**  Returns end position of randomly generated vector form srcPos in direction to/from dirUnit
+**	
+**  @param srcPos   Vector origin
+**  @param dirUnit   Position to determine vector direction
+**	@param dirFrom	Direction of src-dir. True if "from" dirPos, false if "to" dirPos
+**  @param minRange Minimal range to new position
+**	@param devRadius Diviation radius
+**	@param rangeDev Range deviation
 **
-**  @param unit     Unit to move.
-**  @param src      Unit to retreat from.
-**  @param minRange Minimal distance to retreat
-**
-**  @return       	Position to retreat
+**  @return       	Position
 */
-Vec2i PosToRetreat(const CUnit &unit, const CUnit &src, const int minRange)
+Vec2i GetRndPosInDirection(const Vec2i &srcPos, const CUnit &dirUnit, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev = 3) {
 {
-	const Vec2i tilePos = src.tilePos + src.Type->GetHalfTileSize();
-	return PosToRetreat(unit, tilePos, minRange);
+	const Vec2i dirPos = dirUnit.tilePos + dirUnit.Type->GetHalfTileSize();
+	return GetRndPosInDirection(srcPos, dirPos, dirFrom, minRange, devRadius, rangeDev);
 }
 
 /**
-**  Return randomly found position for unit in opposite derection to src
+**  Returns end position of randomly generated vector form srcPos in direction to/from dirPos
+**	
+**  @param srcPos   Vector origin
+**  @param dirPos   Position to determine vector direction
+**	@param dirFrom	Direction of src-dir. True if "from" dirPos, false if "to" dirPos
+**  @param minRange Minimal range to new position
+**	@param devRadius Diviation radius
+**	@param rangeDev Range deviation
 **
-**  @param unit     Unit to move.
-**  @param srcPos   Pos to retreat from.
-**  @param minRange Minimal distance to retreat
-**
-**  @return       	Position to retreat
+**  @return       	Position
 */
-Vec2i PosToRetreat(const CUnit &unit, const Vec2i &srcPos, const int minRange)
-{
-	Vec2i pos = unit.tilePos - srcPos;
+Vec2i GetRndPosInDirection(const Vec2i &srcPos, const Vec2i &dirPos, const bool dirFrom, const int minRange, const int devRadius, const int rangeDev = 3) {
+	Vec2i pos = dirPos - srcPos;
+	pos *= dirFrom ? -1 : 1;
 	int d = isqrt(pos.x * pos.x + pos.y * pos.y);
 
 	if (!d) {
 		d = 1;
 	}
-	pos.x = unit.tilePos.x + (pos.x * (minRange + (SyncRand() % 3))) / d + (2 - (SyncRand() % 5));
-	pos.y = unit.tilePos.y + (pos.y * (minRange + (SyncRand() % 3))) / d + (2 - (SyncRand() % 5));
+	const int range = minRange + (SyncRand() % (rangeDev + 1));
+	pos.x = srcPos.x + (pos.x * range) / d + (devRadius - (SyncRand() % (devRadius * 2 + 1)));
+	pos.y = srcPos.y + (pos.y * range) / d + (devRadius - (SyncRand() % (devRadius * 2 + 1)));
 	Map.Clamp(pos);
 	return pos;
 }

--- a/src/unit/unit_find.cpp
+++ b/src/unit/unit_find.cpp
@@ -960,7 +960,7 @@ public:
 					if (pos >= good->size()) {
 						DebugPrint("BUG: RangeTargetFinder::FillBadGood.Compute out of range. "\
 								   "size: %d, pos: %d, "				\
-								   "x: %d, xx: %d, y: %d, yy: %d" _C_
+								   "x: %d, xx: %d, y: %d, yy: %d\n" _C_
 								   size _C_ pos _C_ x _C_ xx _C_ y _C_ yy);
 						break;
 					}
@@ -985,7 +985,9 @@ public:
 
 	CUnit *Find(std::vector<CUnit *> &table)
 	{
-		FillBadGood(*attacker, range, good, bad, size).Fill(table.begin(), table.end());
+		if (!Preference.SimplifiedAutoTargeting) {
+			FillBadGood(*attacker, range, good, bad, size).Fill(table.begin(), table.end());
+		}
 		return Find(table.begin(), table.end());
 
 	}
@@ -1012,9 +1014,9 @@ private:
 			dest->CacheLock = 0;
 			return;
 		}
+		
 		if (Preference.SimplifiedAutoTargeting) {
-			int cost = TargetPriorityCalculate(attacker, dest); 
-			
+			const int cost = TargetPriorityCalculate(attacker, dest); 
 			if (cost > best_cost) {
 				best_unit = dest;
 				best_cost = cost;
@@ -1051,7 +1053,7 @@ private:
 				if (pos >= good->size()) {
 					DebugPrint("BUG: RangeTargetFinder.Compute out of range. " \
 					       "size: %d, pos: %d, "	\
-					       "x: %d, xx: %d, y: %d, yy: %d" _C_
+					       "x: %d, xx: %d, y: %d, yy: %d \n" _C_
 					       size _C_ pos _C_ x _C_ xx _C_ y _C_ yy);
 					break;
 				}

--- a/src/unit/unit_find.cpp
+++ b/src/unit/unit_find.cpp
@@ -706,17 +706,9 @@ private:
 		for (Iterator it = begin; it != end; ++it) {
 			int cost = Preference.SimplifiedAutoTargeting ? TargetPriorityCalculate(attacker, *it) : ComputeCost(*it);
 			
-			if (Preference.SimplifiedAutoTargeting)
-			{
-				if (cost > best_cost) {
-					enemy = *it;
-					best_cost = cost;
-				}			
-			} else {
-				if (cost < best_cost) {
-					enemy = *it;
-					best_cost = cost;
-				}
+			if (Preference.SimplifiedAutoTargeting ? (cost > best_cost) : (cost < best_cost)) {
+				enemy = *it;
+				best_cost = cost;
 			}
 		}
 		return enemy;

--- a/src/unit/unit_find.cpp
+++ b/src/unit/unit_find.cpp
@@ -221,7 +221,7 @@ class BestDepotFinder
 				d = UnitReachable(*worker, *dest, 1);
 				if (worker->Container) {
 					MarkUnitFieldFlags(*worker->Container);
-				}			
+				}
 				//
 				// Take this depot?
 				//
@@ -548,11 +548,11 @@ void FindPlayerUnitsByType(const CPlayer &player, const CUnitType &type, std::ve
 	if (ai_active) {
 		typecount = player.UnitTypesAiActiveCount[type.Slot];
 	}
-	
+
 	if (typecount < 0) { // if unit type count is negative, something wrong happened
 		fprintf(stderr, "Player %d has a negative %s unit type count of %d.\n", player.Index, type.Ident.c_str(), typecount);
 	}
-	
+
 	if (typecount == 0) {
 		return;
 	}
@@ -705,7 +705,7 @@ private:
 
 		for (Iterator it = begin; it != end; ++it) {
 			int cost = Preference.SimplifiedAutoTargeting ? TargetPriorityCalculate(attacker, *it) : ComputeCost(*it);
-			
+
 			if (Preference.SimplifiedAutoTargeting ? (cost > best_cost) : (cost < best_cost)) {
 				enemy = *it;
 				best_cost = cost;
@@ -1004,7 +1004,7 @@ private:
 	{
 		for (Iterator it = begin; it != end; ++it) {
 			Compute(*it);
-		} 
+		}
 		return best_unit;
 	}
 
@@ -1014,9 +1014,9 @@ private:
 			dest->CacheLock = 0;
 			return;
 		}
-		
+
 		if (Preference.SimplifiedAutoTargeting) {
-			const int cost = TargetPriorityCalculate(attacker, dest); 
+			const int cost = TargetPriorityCalculate(attacker, dest);
 			if (cost > best_cost) {
 				best_unit = dest;
 				best_cost = cost;
@@ -1035,7 +1035,7 @@ private:
 		clamp<int>(&y, dest->tilePos.y, dest->tilePos.y + dtype.TileHeight - 1);
 
 		int sbad = 0;
-		int sgood = 0;		
+		int sgood = 0;
 
 		// cost map is relative to attacker position
 		x = dest->tilePos.x - attacker->tilePos.x + (size / 2);
@@ -1052,9 +1052,9 @@ private:
 				int localFactor = (!xx && !yy) ? 1 : splashFactor;
 				if (pos >= good->size()) {
 					DebugPrint("BUG: RangeTargetFinder.Compute out of range. " \
-					       "size: %d, pos: %d, "	\
-					       "x: %d, xx: %d, y: %d, yy: %d \n" _C_
-					       size _C_ pos _C_ x _C_ xx _C_ y _C_ yy);
+							   "size: %d, pos: %d, "	\
+							   "x: %d, xx: %d, y: %d, yy: %d \n" _C_
+							   size _C_ pos _C_ x _C_ xx _C_ y _C_ yy);
 					break;
 				}
 				sbad += bad->at(pos) / localFactor;
@@ -1171,7 +1171,7 @@ CUnit *AttackUnitsInDistance(const CUnit &unit, int range, CUnitFilter pred)
 		const CUnit *firstContainer = unit.Container ? unit.Container : &unit;
 		std::vector<CUnit *> table;
 		SelectAroundUnit(*firstContainer, missile_range, table,
-			MakeAndPredicate(HasNotSamePlayerAs(Players[PlayerNumNeutral]), pred));
+						 MakeAndPredicate(HasNotSamePlayerAs(Players[PlayerNumNeutral]), pred));
 
 		if (table.empty() == false) {
 			return BestRangeTargetFinder(unit, range).Find(table);
@@ -1183,7 +1183,7 @@ CUnit *AttackUnitsInDistance(const CUnit &unit, int range, CUnitFilter pred)
 		std::vector<CUnit *> table;
 
 		SelectAroundUnit(*firstContainer, range, table,
-			MakeAndPredicate(HasNotSamePlayerAs(Players[PlayerNumNeutral]), pred));
+						 MakeAndPredicate(HasNotSamePlayerAs(Players[PlayerNumNeutral]), pred));
 
 		const int n = static_cast<int>(table.size());
 		if (range > 25 && table.size() > 9) {

--- a/src/unit/unit_find.cpp
+++ b/src/unit/unit_find.cpp
@@ -1001,16 +1001,7 @@ private:
 	CUnit *Find(Iterator begin, Iterator end)
 	{
 		for (Iterator it = begin; it != end; ++it) {
-            if (Preference.SimplifiedAutoTargeting) {
-				int cost = TargetPriorityCalculate(attacker, *it); 
-				
-				if (cost > best_cost) {
-					best_unit = *it;
-					best_cost = cost;
-				}
-			} else { 
-				Compute(*it);
-			}
+			Compute(*it);
 		} 
 		return best_unit;
 	}
@@ -1021,6 +1012,16 @@ private:
 			dest->CacheLock = 0;
 			return;
 		}
+		if (Preference.SimplifiedAutoTargeting) {
+			int cost = TargetPriorityCalculate(attacker, dest); 
+			
+			if (cost > best_cost) {
+				best_unit = dest;
+				best_cost = cost;
+			}
+			return;
+		}
+
 		const CUnitType &type = *attacker->Type;
 		const CUnitType &dtype = *dest->Type;
 		int x = attacker->tilePos.x;


### PR DESCRIPTION
There were some problems with automatic target selection. 
- After receiving attack-move order attacker chose a target and may fixing on it, even if a higher priority target is appeared nearby. F.e. attacker may beat barracks and don't switch to the appeared from it new enemy unit, or may attack farms, but do not switch to peons nearby.
- Unit being under attack by tower, may attack farm, and do not switch target, as result - die.
- etc.

Maybe that wasn't a big problem for single player and campaign, but for multiplayer game that was terrible. 

What was done. 
1. Was made some fixes in original code, now units don't fixed on once selected target when in auto attack mode. Made some refactoring.
2. As an option was implemented [starcraft 2 automatic targeting algorithm](https://liquipedia.net/starcraft2/Automatic_Targeting). With some simplifications of course *(f.e. we don't have units with multiple weapons, closest angle also don't calculating (yet))*, but mainly it was represented. It is simpler than original *(which counts such things as posible splash damage to ally units or if target can be killed by a single shot etc.)*, but IMHO better fit for multiplayer. Because of that it named SimplifiedAutoTargeting.
Target priority briefly:
    * Once a target is chosen, it will remain the target until it ceases being a valid target *(e.g., dies, becomes invisible)*, leaves the `AttackRange` or a higher-priority target enters the `ReactionRange`.
    * A unit (or building) considers all valid targets within it's the `ReactionRange`.
    * The criteria for target selection are, from most to least important:
    -- Which targets are threats to me? *(If it can attack me, or it has `AlwaysThreat` flag set in the unit definition - it's threat)*
    -- Which targets have the highest `Priority` values *(defined in units lua-files)*?
    -- Only if I lost *(e.g., dies, becomes invisible, leaves the `AttackRange`)* my previous target: Which target is the closest and has less % of remaining HP? 'Closest' now mean not direct distance from attacker to target, but path length calculated by path finder, to position where weapon's attack range reaches the target. 
 
3. Added new option `Preference.SimplifiedAutoTargeting` to activate it (switch between original and new "Simplified" algorithm). Also, this was added in Wargus menu lua-script, so now you will be able to activate it from the game menu (For single player game by now. Multiplayer in the ToDo list). PR in wargus: https://github.com/Wargus/wargus/pull/319.
4. Units with `MinAttackRange > 0` now automatically will move to better position if their targets is closer than MinAttackRange (of course if there is no any valid targets in range, or it not in `StandGround` state). 
5. I have to add new variable in the `ActionAttack`, which must be (and now it is) saved in the save-file. So new save-files can't be opened with older version of Stratagus.
6. Units with stand ground command no more play attack animation if their target is closer than `MinAttackRange`.
7. Now for attack-move order it draws two lines - one to current automatically selected target, and the second to the ordered attack-move tile.
8. Some small fixes.
