### PR TITLE
Fixed issue with grayscale application for BPP 4.

### DIFF
--- a/src/video/graphic.cpp
+++ b/src/video/graphic.cpp
@@ -683,7 +683,7 @@ static void ApplyGrayScale(SDL_Surface *Surface, int Width, int Height)
 			Uint32 *p;
 			for (int i = 0; i < Height; ++i) {
 				for (int j = 0; j < Width; ++j) {
-					p = (Uint32 *)(Surface->pixels) + i * Width + j * bpp;
+					p = static_cast<Uint32 *>(Surface->pixels) + (i * Surface->w + j);
 					const Uint32 gray = ((Uint8)((*p) * redGray) >> f->Rshift) +
 										((Uint8)(*(p + 1) * greenGray) >> f->Gshift) +
 										((Uint8)(*(p + 2) * blueGray) >> f->Bshift) +


### PR DESCRIPTION
@Andrettin :
>There are two issues there
first, the lack of parenthesis was making only the "j" (= X) be multiplied by the BPP, instead of the whole "i * Width + j" as would make sense
And two, since the pointer is to an uint32 (4 bytes), instead of a type that has a single byte, it shouldn't be multiplied by the BPP at all