### PR TITLE
Fix issue with unfinishable action-move.

### DIFF
--- a/src/action/action_move.cpp
+++ b/src/action/action_move.cpp
@@ -256,6 +256,18 @@ int DoActionMove(CUnit &unit)
 		case PF_REACHED:
 			this->Finished = true;
 			break;
+			
+		case PF_WAIT: 
+		{
+			const CUnit *blocker = UnitOnMapTile(this->goalPos, unit.Type->UnitType);
+			if (blocker) { 
+				const int distToBlocker = MapDistanceBetweenTypes(*(unit.Type), unit.tilePos, *(blocker->Type), blocker->tilePos);
+				if (distToBlocker == 1 && (unit.IsEnemy(*blocker) || blocker->Moving == false)) {
+					unit.Wait = 0;
+					this->Finished = true;
+				}
+			}
+		}	break;
 		default:
 			break;
 	}


### PR DESCRIPTION
Units in the action-move will not finish action if any unit come to their goalPos-tile, or being build on it. They will stay on the neighbour tile inactive (actually it will be in permanent waiting state initiated by `DoActionMove()`).

This PR added additional check for `DoActionMove()` result, and will finish action if aforementioned event occurs.