### PR TITLE
Improved the performance of the shared vision code.

### DIFF
--- a/src/action/command.cpp
+++ b/src/action/command.cpp
@@ -924,13 +924,13 @@ void CommandSharedVision(int player, bool state, int opponent)
 	}
 
 	// Compute Before and after.
-	const int before = Players[player].IsBothSharedVision(Players[opponent]);
+	const int before = Players[player].HasMutualSharedVisionWith(Players[opponent]);
 	if (state == false) {
 		Players[player].UnshareVisionWith(Players[opponent]);
 	} else {
 		Players[player].ShareVisionWith(Players[opponent]);
 	}
-	const int after = Players[player].IsBothSharedVision(Players[opponent]);
+	const int after = Players[player].HasMutualSharedVisionWith(Players[opponent]);
 
 	if (before && !after) {
 		// Don't share vision anymore. Give each other explored terrain for good-bye.

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -36,6 +36,7 @@
 --  Includes
 ----------------------------------------------------------------------------*/
 
+#include <set>
 #include <string>
 
 #include "color.h"
@@ -213,10 +214,14 @@ public:
 	bool IsAllied(const CPlayer &player) const;
 	bool IsAllied(const CUnit &unit) const;
 	bool IsVisionSharing() const;
-	bool IsSharedVision(const CPlayer &player) const;
-	bool IsSharedVision(const CUnit &unit) const;
-	bool IsBothSharedVision(const CPlayer &player) const;
-	bool IsBothSharedVision(const CUnit &unit) const;
+	const std::set<int> &GetSharedVision() const
+	{
+		return this->SharedVision;
+	}
+	bool HasSharedVisionWith(const CPlayer &player) const;
+	bool HasSharedVisionWith(const CUnit &unit) const;
+	bool HasMutualSharedVisionWith(const CPlayer &player) const;
+	bool HasMutualSharedVisionWith(const CUnit &unit) const;
 	bool IsTeamed(const CPlayer &player) const;
 	bool IsTeamed(const CUnit &unit) const;
 
@@ -236,7 +241,7 @@ private:
 	std::vector<CUnit *> Units; /// units of this player
 	unsigned int Enemy;         /// enemy bit field for this player
 	unsigned int Allied;        /// allied bit field for this player
-	unsigned int SharedVision;  /// shared vision bit field
+	std::set<int> SharedVision; /// set of player indexes that this player has shared vision with
 };
 
 /**

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -192,8 +192,8 @@ public:
 
 	inline bool IsInvisibile(const CPlayer &player) const
 	{
-		return (&player != Player && !!Variable[INVISIBLE_INDEX].Value
-				&& !player.IsBothSharedVision(*Player));
+		return (&player != Player && Variable[INVISIBLE_INDEX].Value > 0
+				&& !player.HasMutualSharedVisionWith(*Player));
 	}
 
 	/**
@@ -268,10 +268,10 @@ public:
 	bool IsEnemy(const CUnit &unit) const;
 	bool IsAllied(const CPlayer &player) const;
 	bool IsAllied(const CUnit &unit) const;
-	bool IsSharedVision(const CPlayer &player) const;
-	bool IsSharedVision(const CUnit &unit) const;
-	bool IsBothSharedVision(const CPlayer &player) const;
-	bool IsBothSharedVision(const CUnit &unit) const;
+	bool HasSharedVisionWith(const CPlayer &player) const;
+	bool HasSharedVisionWith(const CUnit &unit) const;
+	bool HasMutualSharedVisionWith(const CPlayer &player) const;
+	bool HasMutualSharedVisionWith(const CUnit &unit) const;
 	bool IsTeamed(const CPlayer &player) const;
 	bool IsTeamed(const CUnit &unit) const;
 

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -138,7 +138,7 @@ public:
 			if (!unit->VisCount[p]) {
 				for (int pi = 0; pi < PlayerMax; ++pi) {
 					if ((pi == p /*player->Index*/)
-						|| player->IsBothSharedVision(Players[pi])) {
+						|| player->HasMutualSharedVisionWith(Players[pi])) {
 						if (!unit->IsVisible(Players[pi])) {
 							UnitGoesOutOfFog(*unit, Players[pi]);
 						}
@@ -165,7 +165,7 @@ public:
 			if (!unit->VisCount[p]) {
 				for (int pi = 0; pi < PlayerMax; ++pi) {
 					if (pi == p/*player->Index*/ ||
-						player->IsBothSharedVision(Players[pi])) {
+						player->HasMutualSharedVisionWith(Players[pi])) {
 						if (!unit->IsVisible(Players[pi])) {
 							UnitGoesUnderFog(*unit, Players[pi]);
 						}

--- a/src/map/map_radar.cpp
+++ b/src/map/map_radar.cpp
@@ -61,11 +61,11 @@ IsTileRadarVisible(const CPlayer &pradar, const CPlayer &punit, const CMapFieldP
 		// Check jamming first, if we are jammed, exit
 		for (int i = 0; i < PlayerMax; ++i) {
 			if (i != p) {
-				if (jamming[i] > 0 && punit.IsBothSharedVision(Players[i])) {
+				if (jamming[i] > 0 && punit.HasMutualSharedVisionWith(Players[i])) {
 					// We are jammed, return nothing
 					return 0;
 				}
-				if (radar[i] > 0 && pradar.IsBothSharedVision(Players[i])) {
+				if (radar[i] > 0 && pradar.HasMutualSharedVisionWith(Players[i])) {
 					radarvision |= radar[i];
 				}
 			}

--- a/src/map/mapfield.cpp
+++ b/src/map/mapfield.cpp
@@ -266,8 +266,8 @@ unsigned char CMapFieldPlayerInfo::TeamVisibilityState(const CPlayer &player) co
 	if (IsExplored(player)) {
 		maxVision = 1;
 	}
-	for (int i = 0; i != PlayerMax ; ++i) {
-		if (player.IsBothSharedVision(Players[i])) {
+	for (const int i : player.GetSharedVision()) {
+		if (player.HasMutualSharedVisionWith(Players[i])) {
 			maxVision = std::max<unsigned char>(maxVision, Visible[i]);
 			if (maxVision >= 2) {
 				return 2;

--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -139,7 +139,7 @@
 **
 **  CPlayer::SharedVision
 **
-**    A bit field which contains shared vision for this player.
+**    Contains shared vision for this player.
 **    Shared vision only works when it's activated both ways. Really.
 **
 **  CPlayer::StartX CPlayer::StartY
@@ -445,7 +445,7 @@ void CPlayer::Save(CFile &file) const
 	}
 	file.printf("\", \"shared-vision\", \"");
 	for (int j = 0; j < PlayerMax; ++j) {
-		file.printf("%c", (p.SharedVision & (1 << j)) ? 'X' : '_');
+		file.printf("%c", (p.SharedVision.find(j) != p.SharedVision.end()) ? 'X' : '_');
 	}
 	file.printf("\",\n  \"start\", {%d, %d},\n", p.StartPos.x, p.StartPos.y);
 
@@ -744,7 +744,7 @@ void CPlayer::Clear()
 	Team = 0;
 	Enemy = 0;
 	Allied = 0;
-	SharedVision = 0;
+	SharedVision.clear();
 	StartPos.x = 0;
 	StartPos.y = 0;
 	memset(Resources, 0, sizeof(Resources));
@@ -1363,12 +1363,12 @@ void CPlayer::SetDiplomacyCrazyWith(const CPlayer &player)
 
 void CPlayer::ShareVisionWith(const CPlayer &player)
 {
-	this->SharedVision |= (1 << player.Index);
+	this->SharedVision.insert(player.Index);
 }
 
 void CPlayer::UnshareVisionWith(const CPlayer &player)
 {
-	this->SharedVision &= ~(1 << player.Index);
+	this->SharedVision.erase(player.Index);
 }
 
 
@@ -1407,40 +1407,40 @@ bool CPlayer::IsAllied(const CUnit &unit) const
 
 bool CPlayer::IsVisionSharing() const
 {
-	return SharedVision != 0;
+	return !this->SharedVision.empty();
 }
 
 /**
 **  Check if the player shares vision with the player
 */
-bool CPlayer::IsSharedVision(const CPlayer &player) const
+bool CPlayer::HasSharedVisionWith(const CPlayer &player) const
 {
-	return (SharedVision & (1 << player.Index)) != 0;
+	return this->SharedVision.find(player.Index) != this->SharedVision.end();
 }
 
 /**
 **  Check if the player shares vision with the unit
 */
-bool CPlayer::IsSharedVision(const CUnit &unit) const
+bool CPlayer::HasSharedVisionWith(const CUnit &unit) const
 {
-	return IsSharedVision(*unit.Player);
+	return this->HasSharedVisionWith(*unit.Player);
 }
 
 /**
 **  Check if the both players share vision
 */
-bool CPlayer::IsBothSharedVision(const CPlayer &player) const
+bool CPlayer::HasMutualSharedVisionWith(const CPlayer &player) const
 {
-	return (SharedVision & (1 << player.Index)) != 0
-		   && (player.SharedVision & (1 << Index)) != 0;
+	return this->SharedVision.find(player.Index) != this->SharedVision.end()
+	 		&& player.SharedVision.find(this->Index) != player.SharedVision.end();
 }
 
 /**
 **  Check if the player and the unit share vision
 */
-bool CPlayer::IsBothSharedVision(const CUnit &unit) const
+bool CPlayer::HasMutualSharedVisionWith(const CUnit &unit) const
 {
-	return IsBothSharedVision(*unit.Player);
+	return this->HasMutualSharedVisionWith(*unit.Player);
 }
 
 /**

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -153,9 +153,9 @@ void CPlayer::Load(lua_State *l)
 			value = LuaToString(l, j + 1);
 			for (int i = 0; i < PlayerMax && *value; ++i, ++value) {
 				if (*value == '-' || *value == '_' || *value == ' ') {
-					this->SharedVision &= ~(1 << i);
+					this->SharedVision.erase(i);
 				} else {
-					this->SharedVision |= (1 << i);
+					this->SharedVision.insert(i);
 				}
 			}
 		} else if (!strcmp(value, "start")) {

--- a/src/tolua/player.pkg
+++ b/src/tolua/player.pkg
@@ -58,10 +58,10 @@ class CPlayer
 	bool IsEnemy(const CUnit &unit) const;
 	bool IsAllied(const CPlayer &player) const;
 	bool IsAllied(const CUnit &unit) const;
-	bool IsSharedVision(const CPlayer &player) const;
-	bool IsSharedVision(const CUnit &unit) const;
-	bool IsBothSharedVision(const CPlayer &player) const;
-	bool IsBothSharedVision(const CUnit &unit) const;
+	bool HasSharedVisionWith(const CPlayer &player) const;
+	bool HasSharedVisionWith(const CUnit &unit) const;
+	bool HasMutualSharedVisionWith(const CPlayer &player) const;
+	bool HasMutualSharedVisionWith(const CUnit &unit) const;
 	bool IsTeamed(const CPlayer &player) const;
 	bool IsTeamed(const CUnit &unit) const;
 };

--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -1028,7 +1028,7 @@ void UIHandleMouseMove(const PixelPos &cursorPos)
 			CMapField &mf = *Map.Field(tilePos);
 			for (int i = 0; i < PlayerMax; ++i) {
 				if (mf.playerInfo.IsExplored(Players[i])
-					&& (i == ThisPlayer->Index || Players[i].IsBothSharedVision(*ThisPlayer))) {
+					&& (i == ThisPlayer->Index || Players[i].HasMutualSharedVisionWith(*ThisPlayer))) {
 					show = true;
 					break;
 				}

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -1645,8 +1645,8 @@ bool CUnit::IsVisible(const CPlayer &player) const
 	if (VisCount[player.Index]) {
 		return true;
 	}
-	for (int p = 0; p < PlayerMax; ++p) {
-		if (p != player.Index && player.IsBothSharedVision(Players[p])) {
+	for (const int p : player.GetSharedVision()) {
+		if (player.HasMutualSharedVisionWith(Players[p])) {
 			if (VisCount[p]) {
 				return true;
 			}
@@ -3280,9 +3280,9 @@ bool CUnit::IsAllied(const CUnit &unit) const
 **
 **  @param x  Player to check
 */
-bool CUnit::IsSharedVision(const CPlayer &player) const
+bool CUnit::HasSharedVisionWith(const CPlayer &player) const
 {
-	return this->Player->IsSharedVision(player);
+	return this->Player->HasSharedVisionWith(player);
 }
 
 /**
@@ -3290,9 +3290,9 @@ bool CUnit::IsSharedVision(const CPlayer &player) const
 **
 **  @param x  Unit to check
 */
-bool CUnit::IsSharedVision(const CUnit &unit) const
+bool CUnit::HasSharedVisionWith(const CUnit &unit) const
 {
-	return IsSharedVision(*unit.Player);
+	return this->HasSharedVisionWith(*unit.Player);
 }
 
 /**
@@ -3300,9 +3300,9 @@ bool CUnit::IsSharedVision(const CUnit &unit) const
 **
 **  @param x  Player to check
 */
-bool CUnit::IsBothSharedVision(const CPlayer &player) const
+bool CUnit::HasMutualSharedVisionWith(const CPlayer &player) const
 {
-	return this->Player->IsBothSharedVision(player);
+	return this->Player->HasMutualSharedVisionWith(player);
 }
 
 /**
@@ -3310,9 +3310,9 @@ bool CUnit::IsBothSharedVision(const CPlayer &player) const
 **
 **  @param x  Unit to check
 */
-bool CUnit::IsBothSharedVision(const CUnit &unit) const
+bool CUnit::HasMutualSharedVisionWith(const CUnit &unit) const
 {
-	return IsBothSharedVision(*unit.Player);
+	return this->HasMutualSharedVisionWith(*unit.Player);
 }
 
 /**


### PR DESCRIPTION
@Andrettin:
>I just made a change that resulted in the visibility-checking code becoming a lot faster
when checking for visibility of a unit or tile.
Instead of looping through ALL players and checking if each has shared vision with the "this" player and if they see the unit.
I made shared vision be stored in the player instance as a set of player indexes. So then I just iterate over the other players the player actually has shared vision with.
This is specially important for when moving the mouse, because
when you move the mouse, it checks to see if ALL units are visible and on the viewport

Original commit: https://github.com/Andrettin/Wyrmgus/commit/ac15658ec515cfc7bb8e723961d066a3a6cb17ae

There is two corresponding PRs:
For wargus: https://github.com/Wargus/wargus/pull/326
For war1gus: https://github.com/Wargus/war1gus/pull/162