### PR TITLE
Add units revelation for players, which had lost their last Town Hall.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: cpp
-os:
-  - linux
-  - osx
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+    - os: osx
 addons:
   apt:
     packages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ before_build:
   - 7z x dependencies.zip
   - appveyor DownloadFile https://github.com/jimpark/unsis/releases/download/2.50.0/nsis-2.50.0-Unicode-setup.exe
   - nsis-2.50.0-Unicode-setup.exe /S /D=C:\Program Files (x86)\NSIS
-  - cmake -G "Visual Studio 14 2015" -T v140_xp -DCMAKE_PREFIX_PATH="%cd%\\dependencies" -DENABLE_NSIS=ON -DENABLE_STDIO_REDIRECT=ON ..
+  - cmake -G "Visual Studio 16 2019" -T v140_xp -DCMAKE_PREFIX_PATH="%cd%\\dependencies" -DENABLE_NSIS=ON -DENABLE_STDIO_REDIRECT=ON ..
   - cd ..
 after_build:
   - 7z a compiled-binaries.zip %cd%\build\stratagus.exe %cd%\build\dependencies\bin\*.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ before_build:
   - 7z x dependencies.zip
   - appveyor DownloadFile https://github.com/jimpark/unsis/releases/download/2.50.0/nsis-2.50.0-Unicode-setup.exe
   - nsis-2.50.0-Unicode-setup.exe /S /D=C:\Program Files (x86)\NSIS
-  - cmake -G "Visual Studio 16 2019" -T v140_xp -DCMAKE_PREFIX_PATH="%cd%\\dependencies" -DENABLE_NSIS=ON -DENABLE_STDIO_REDIRECT=ON ..
+  - cmake -G "Visual Studio 16 2019" -T v141_xp -DCMAKE_PREFIX_PATH="%cd%\\dependencies" -DENABLE_NSIS=ON -DENABLE_STDIO_REDIRECT=ON ..
   - cd ..
 after_build:
   - 7z a compiled-binaries.zip %cd%\build\stratagus.exe %cd%\build\dependencies\bin\*.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ before_build:
   - 7z x dependencies.zip
   - appveyor DownloadFile https://github.com/jimpark/unsis/releases/download/2.50.0/nsis-2.50.0-Unicode-setup.exe
   - nsis-2.50.0-Unicode-setup.exe /S /D=C:\Program Files (x86)\NSIS
-  - cmake -G "Visual Studio 16 2019" -T v141_xp -DCMAKE_PREFIX_PATH="%cd%\\dependencies" -DENABLE_NSIS=ON -DENABLE_STDIO_REDIRECT=ON ..
+  - cmake -G "Visual Studio 16 2019" -T v141_xp -A win32 -DCMAKE_PREFIX_PATH="%cd%\\dependencies" -DENABLE_NSIS=ON -DENABLE_STDIO_REDIRECT=ON ..
   - cd ..
 after_build:
   - 7z a compiled-binaries.zip %cd%\build\stratagus.exe %cd%\build\dependencies\bin\*.dll

--- a/src/action/action_build.cpp
+++ b/src/action/action_build.cpp
@@ -345,6 +345,20 @@ bool COrder_Build::StartBuilding(CUnit &unit, CUnit &ontop)
 			ontop.Release();
 		}
 	}
+	
+	if (type.BoolFlag[MAINFACILITY_INDEX].value 
+	&& CPlayer::IsRevelationEnabled() && unit.Player->LostMainFacilityTimer != 0 ) {
+		
+		unit.Player->LostMainFacilityTimer = 0;
+		unit.Player->SetRevealed(false);
+		for (int j = 0; j < NumPlayers; ++j) {
+			if (unit.Player->Index != j && Players[j].Type != PlayerNobody) {
+				Players[j].Notify(_("%s has rebuilt a base, and will no longer be revealed!"), unit.Player->Name.c_str());
+			} else {
+				Players[j].Notify("%s", _("You have rebuilt a base, and will no longer be revealed!"));
+			}
+		}
+	}
 
 	// Must set action before placing, otherwise it will incorrectly mark radar
 	delete build->CurrentOrder();

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -82,7 +82,7 @@ class CPlayer
 {
 public:
 	static inline enum ERevelations { cNoRrevelation, cAllUnits, cBuildingsOnly } 
-		RevelationFor; /// type of revelation (when player lost their last main facility)
+		RevelationFor {cNoRrevelation}; /// type of revelation (when player lost their last main facility)
 
 public:
 	/// Check if relevation enabled

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -79,7 +79,7 @@ enum _diplomacy_ {
 
 enum class RevealTypes 
 { 
-	cNoRrevelation, 
+	cNoRevelation, 
 	cAllUnits, 
 	cBuildingsOnly 
 }; /// Revelation types
@@ -88,14 +88,14 @@ enum class RevealTypes
 class CPlayer
 {
 public:
-	static inline RevealTypes RevelationFor { RevealTypes::cNoRrevelation }; /// type of revelation (when player lost their last main facility)
+	static inline RevealTypes RevelationFor { RevealTypes::cNoRevelation }; /// type of revelation (when player lost their last main facility)
 
 public:
 	/// Check if relevation enabled
 	static const bool IsRevelationEnabled()
 	{
 		// By default there is no revelation. Can be changed in lua-script
-		return CPlayer::RevelationFor != RevealTypes::cNoRrevelation; 
+		return CPlayer::RevelationFor != RevealTypes::cNoRevelation; 
 	}
 	/// Change revelation type
 	static void SetRevelationType(const RevealTypes type);

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -77,22 +77,28 @@ enum _diplomacy_ {
 	DiplomacyCrazy     /// Ally and attack opponent
 }; /// Diplomacy states for CommandDiplomacy
 
+enum class RevealTypes 
+{ 
+	cNoRrevelation, 
+	cAllUnits, 
+	cBuildingsOnly 
+}; /// Revelation types
+
 ///  Player structure
 class CPlayer
 {
 public:
-	static inline enum ERevelations { cNoRrevelation, cAllUnits, cBuildingsOnly } 
-		RevelationFor {cNoRrevelation}; /// type of revelation (when player lost their last main facility)
+	static inline RevealTypes RevelationFor { RevealTypes::cNoRrevelation }; /// type of revelation (when player lost their last main facility)
 
 public:
 	/// Check if relevation enabled
 	static const bool IsRevelationEnabled()
 	{
 		// By default there is no revelation. Can be changed in lua-script
-		return CPlayer::RevelationFor != cNoRrevelation; 
+		return CPlayer::RevelationFor != RevealTypes::cNoRrevelation; 
 	}
 	/// Change revelation type
-	static void SetRevelationType(const ERevelations type);
+	static void SetRevelationType(const RevealTypes type);
 	/// Get revealed players list
 	static const std::vector<const CPlayer *> &GetRevealedPlayers()
 	{

--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -173,6 +173,7 @@ enum {
 	SKIRMISHER_INDEX,
 	ALWAYSTHREAT_INDEX,				/// Unit always considered as threat for auto targeting algorihm, useful for unit without main attack ability, but which can cast spells (f.e. defiler in SC:BW)
 	NOFRIENDLYFIRE_INDEX,           /// Unit accepts friendly fire for splash attacks
+	MAINFACILITY_INDEX,				/// Unit is a main building (Town Hall f. ex.)
 	NBARALREADYDEFINED
 };
 

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -138,7 +138,7 @@ public:
 			if (!unit->VisCount[p]) {
 				for (int pi = 0; pi < PlayerMax; ++pi) {
 					if ((pi == p /*player->Index*/)
-						|| player->HasMutualSharedVisionWith(Players[pi])) {
+						|| player->HasMutualSharedVisionWith(Players[pi])) { 
 						if (!unit->IsVisible(Players[pi])) {
 							UnitGoesOutOfFog(*unit, Players[pi]);
 						}

--- a/src/map/mapfield.cpp
+++ b/src/map/mapfield.cpp
@@ -266,6 +266,7 @@ unsigned char CMapFieldPlayerInfo::TeamVisibilityState(const CPlayer &player) co
 	if (IsExplored(player)) {
 		maxVision = 1;
 	}
+	
 	for (const int i : player.GetSharedVision()) {
 		if (player.HasMutualSharedVisionWith(Players[i])) {
 			maxVision = std::max<unsigned char>(maxVision, Visible[i]);
@@ -274,6 +275,7 @@ unsigned char CMapFieldPlayerInfo::TeamVisibilityState(const CPlayer &player) co
 			}
 		}
 	}
+
 	if (maxVision == 1 && Map.NoFogOfWar) {
 		return 2;
 	}

--- a/src/map/minimap.cpp
+++ b/src/map/minimap.cpp
@@ -290,7 +290,7 @@ static void DrawUnitOn(CUnit &unit, int red_phase)
 {
 	const CUnitType *type;
 
-	if (Editor.Running || ReplayRevealMap || unit.IsVisible(*ThisPlayer)) {
+	if (Editor.Running || ReplayRevealMap || unit.IsVisible(*ThisPlayer) || unit.Player->IsRevealed()) {
 		type = unit.Type;
 	} else {
 		type = unit.Seen.Type;

--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -338,7 +338,7 @@ int PlayerColorIndexCount;
 */
 void CPlayer::SetRevelationType(const RevealTypes type)
 {
-	if (type >= RevealTypes::cNoRrevelation && type <= RevealTypes::cBuildingsOnly) {
+	if (type >= RevealTypes::cNoRevelation && type <= RevealTypes::cBuildingsOnly) {
 		CPlayer::RevelationFor = type;
 	}
 }

--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -334,6 +334,16 @@ int PlayerColorIndexCount;
 ----------------------------------------------------------------------------*/
 
 /**
+**  Change revelation type
+*/
+void CPlayer::SetRevelationType(const ERevelations type)
+{
+	if (type >= cNoRrevelation && type <= cBuildingsOnly) {
+		CPlayer::RevelationFor = type;
+	}
+}
+
+/**
 **  Clean up the PlayerRaces names.
 */
 void PlayerRace::Clean()
@@ -379,6 +389,7 @@ void InitPlayers()
 void CleanPlayers()
 {
 	ThisPlayer = NULL;
+	CPlayer::RevealedPlayers.clear();
 	for (unsigned int i = 0; i < PlayerMax; ++i) {
 		Players[i].Clear();
 	}
@@ -415,6 +426,25 @@ void SavePlayers(CFile &file)
 	file.printf("SetThisPlayer(%d)\n\n", ThisPlayer->Index);
 }
 
+/**
+ **	Add/remove players to/from list of revealed players
+ */
+void CPlayer::SetRevealed(const bool revealed)
+{
+	if (revealed == this->IsRevealed()) {
+		return;
+	}
+	this->isRevealed = revealed;
+	
+	std::vector<const CPlayer *> &revealedPlayers = CPlayer::RevealedPlayers;
+	if (revealed) {
+		revealedPlayers.push_back(this);
+	} else {
+		/// Remove element from vector;
+		revealedPlayers.erase(std::remove(revealedPlayers.begin(), revealedPlayers.end(), this), 
+							  revealedPlayers.end());
+	}
+}
 
 void CPlayer::Save(CFile &file) const
 {
@@ -503,6 +533,9 @@ void CPlayer::Save(CFile &file) const
 	// TotalNumUnits done by load units.
 	// NumBuildings done by load units.
 
+	if (p.IsRevealed()) {
+		file.printf(" \"revealed\",");
+	}
 	file.printf(" \"supply\", %d,", p.Supply);
 	file.printf(" \"unit-limit\", %d,", p.UnitLimit);
 	file.printf(" \"building-limit\", %d,", p.BuildingLimit);
@@ -522,6 +555,9 @@ void CPlayer::Save(CFile &file) const
 	file.printf("\n  \"total-razings\", %d,", p.TotalRazings);
 	file.printf("\n  \"total-kills\", %d,", p.TotalKills);
 
+	if (p.LostMainFacilityTimer != 0) {
+		file.printf("\n  \"lost-main-facility-timer\", %d,", p.LostMainFacilityTimer);
+	}
 	file.printf("\n  \"speed-resource-harvest\", {");
 	for (int j = 0; j < MaxCosts; ++j) {
 		if (j) {
@@ -715,6 +751,8 @@ void CPlayer::Init(/* PlayerTypes */ int type)
 	} else {
 		this->AiEnabled = false;
 	}
+	this->LostMainFacilityTimer = 0;
+	this->isRevealed = false;
 	++NumPlayers;
 }
 
@@ -772,6 +810,7 @@ void CPlayer::Clear()
 	memset(TotalResources, 0, sizeof(TotalResources));
 	TotalRazings = 0;
 	TotalKills = 0;
+	this->LostMainFacilityTimer = 0;
 	Color = 0;
 	UpgradeTimers.Clear();
 	for (int i = 0; i < MaxCosts; ++i) {
@@ -782,6 +821,7 @@ void CPlayer::Clear()
 	SpeedTrain = SPEEDUP_FACTOR;
 	SpeedUpgrade = SPEEDUP_FACTOR;
 	SpeedResearch = SPEEDUP_FACTOR;
+	this->isRevealed = false;
 }
 
 
@@ -1163,7 +1203,18 @@ void PlayersEachCycle()
 {
 	for (int player = 0; player < NumPlayers; ++player) {
 		CPlayer &p = Players[player];
-
+		if (CPlayer::IsRevelationEnabled()) {
+			if (p.LostMainFacilityTimer && !p.IsRevealed() && p.LostMainFacilityTimer < ((int) GameCycle)) {
+				p.SetRevealed(true);
+				for (int j = 0; j < NumPlayers; ++j) {
+					if (player != j && Players[j].Type != PlayerNobody) {
+						Players[j].Notify(_("%s has not rebuilt their base and is being revealed!"), p.Name.c_str());
+					} else {
+						Players[j].Notify("%s", _("You have not rebuilt your base and have been revealed!"));
+					}
+				}
+			}
+		}
 		if (p.AiEnabled) {
 			AiEachCycle(p);
 		}

--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -336,9 +336,9 @@ int PlayerColorIndexCount;
 /**
 **  Change revelation type
 */
-void CPlayer::SetRevelationType(const ERevelations type)
+void CPlayer::SetRevelationType(const RevealTypes type)
 {
-	if (type >= cNoRrevelation && type <= cBuildingsOnly) {
+	if (type >= RevealTypes::cNoRrevelation && type <= RevealTypes::cBuildingsOnly) {
 		CPlayer::RevelationFor = type;
 	}
 }

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -530,7 +530,7 @@ static int CclSetRevelationType(lua_State *l)
 
 	const char *revel_type = LuaToString(l, 1);
 	if (!strcmp(revel_type, "no-revelation")) {
-		CPlayer::SetRevelationType(RevealTypes::cNoRrevelation);
+		CPlayer::SetRevelationType(RevealTypes::cNoRevelation);
 	} else if (!strcmp(revel_type, "all-units")) {
 		CPlayer::SetRevelationType(RevealTypes::cAllUnits);
 	} else if (!strcmp(revel_type, "buildings-only")) {

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -530,11 +530,11 @@ static int CclSetRevelationType(lua_State *l)
 
 	const char *revel_type = LuaToString(l, 1);
 	if (!strcmp(revel_type, "no-revelation")) {
-		CPlayer::SetRevelationType(CPlayer::cNoRrevelation);
+		CPlayer::SetRevelationType(RevealTypes::cNoRrevelation);
 	} else if (!strcmp(revel_type, "all-units")) {
-		CPlayer::SetRevelationType(CPlayer::cAllUnits);
+		CPlayer::SetRevelationType(RevealTypes::cAllUnits);
 	} else if (!strcmp(revel_type, "buildings-only")) {
-		CPlayer::SetRevelationType(CPlayer::cBuildingsOnly);
+		CPlayer::SetRevelationType(RevealTypes::cBuildingsOnly);
 	} else {
 		PrintFunction();
 		fprintf(stdout, "Accessible types of revelation \"no-revelation\", \"all-units\" and \"buildings-only\".\n");

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -235,6 +235,9 @@ void CPlayer::Load(lua_State *l)
 		} else if (!strcmp(value, "ai-disabled")) {
 			this->AiEnabled = false;
 			--j;
+		} else if (!strcmp(value, "revealed")) {
+			this->SetRevealed(true); 
+			--j;	
 		} else if (!strcmp(value, "supply")) {
 			this->Supply = LuaToNumber(l, j + 1);
 		} else if (!strcmp(value, "demand")) {
@@ -255,6 +258,8 @@ void CPlayer::Load(lua_State *l)
 			this->TotalRazings = LuaToNumber(l, j + 1);
 		} else if (!strcmp(value, "total-kills")) {
 			this->TotalKills = LuaToNumber(l, j + 1);
+		} else if (!strcmp(value, "lost-main-facility-timer")) {
+			this->LostMainFacilityTimer = LuaToNumber(l, j + 1);
 		} else if (!strcmp(value, "total-resources")) {
 			if (!lua_istable(l, j + 1)) {
 				LuaError(l, "incorrect argument");
@@ -512,6 +517,30 @@ static int CclSharedVision(lua_State *l)
 	lua_pushnumber(l, ThisPlayer->Index);
 	lua_insert(l, 1);
 	return CclSetSharedVision(l);
+}
+
+/**
+**  Change the players revelation type - reveal all units, only buidings or don't reveal anything
+**
+**  @param l  Lua state.
+*/
+static int CclSetRevelationType(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+
+	const char *revel_type = LuaToString(l, 1);
+	if (!strcmp(revel_type, "no-revelation")) {
+		CPlayer::SetRevelationType(CPlayer::cNoRrevelation);
+	} else if (!strcmp(revel_type, "all-units")) {
+		CPlayer::SetRevelationType(CPlayer::cAllUnits);
+	} else if (!strcmp(revel_type, "buildings-only")) {
+		CPlayer::SetRevelationType(CPlayer::cBuildingsOnly);
+	} else {
+		PrintFunction();
+		fprintf(stdout, "Accessible types of revelation \"no-revelation\", \"all-units\" and \"buildings-only\".\n");
+		return 1;
+	}
+	return 0;
 }
 
 /**
@@ -938,6 +967,8 @@ void PlayerCclRegister()
 	lua_register(Lua, "Diplomacy", CclDiplomacy);
 	lua_register(Lua, "SetSharedVision", CclSetSharedVision);
 	lua_register(Lua, "SharedVision", CclSharedVision);
+	
+	lua_register(Lua, "SetRevelationType", CclSetRevelationType);
 
 	lua_register(Lua, "DefineRaceNames", CclDefineRaceNames);
 	lua_register(Lua, "DefineNewRaceNames", CclDefineRaceNames);

--- a/src/unit/script_unittype.cpp
+++ b/src/unit/script_unittype.cpp
@@ -96,6 +96,7 @@ static const char SIDEATTACK_KEY[] = "SideAttack";
 static const char SKIRMISHER_KEY[] = "Skirmisher";
 static const char ALWAYSTHREAT_KEY[] = "AlwaysThreat";
 static const char NOFRIENDLYFIRE_KEY[] = "NoFriendlyFire";
+static const char MAINFACILITY_KEY[] = "MainFacility";
 
 // names of the variable.
 static const char HITPOINTS_KEY[] = "HitPoints";
@@ -154,7 +155,7 @@ CUnitTypeVar::CBoolKeys::CBoolKeys()
 							   BUILDERLOST_KEY, CANHARVEST_KEY, HARVESTER_KEY, SELECTABLEBYRECTANGLE_KEY,
 							   ISNOTSELECTABLE_KEY, DECORATION_KEY, INDESTRUCTIBLE_KEY, TELEPORTER_KEY, SHIELDPIERCE_KEY,
 							   SAVECARGO_KEY, NONSOLID_KEY, WALL_KEY, NORANDOMPLACING_KEY, ORGANIC_KEY, SIDEATTACK_KEY, SKIRMISHER_KEY,
-							   ALWAYSTHREAT_KEY, NOFRIENDLYFIRE_KEY
+							   ALWAYSTHREAT_KEY, NOFRIENDLYFIRE_KEY, MAINFACILITY_KEY
 							  };
 
 	for (int i = 0; i < NBARALREADYDEFINED; ++i) {

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -1692,7 +1692,7 @@ bool CUnit::IsVisibleOnMinimap() const
 	}
 	if (IsVisible(*ThisPlayer) || ReplayRevealMap || IsVisibleOnRadar(*ThisPlayer) 
 		|| (CPlayer::IsRevelationEnabled() && Player->IsRevealed() 
-			&& (CPlayer::RevelationFor == CPlayer::cAllUnits || this->Type->BoolFlag[BUILDING_INDEX].value))) {
+			&& (CPlayer::RevelationFor == RevealTypes::cAllUnits || this->Type->BoolFlag[BUILDING_INDEX].value))) {
 		return IsAliveOnMap();
 	} else {
 		return Type->BoolFlag[VISIBLEUNDERFOG_INDEX].value && Seen.State != 3

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -1321,6 +1321,26 @@ void UnitLost(CUnit &unit)
 		}
 	}
 
+	if (type.BoolFlag[MAINFACILITY_INDEX].value && CPlayer::IsRevelationEnabled()) {
+		bool lost_town_hall = true;
+		for (int j = 0; j < player.GetUnitCount(); ++j) {
+			if (player.GetUnit(j).Type->BoolFlag[MAINFACILITY_INDEX].value) {
+				lost_town_hall = false;
+				break;
+			}
+		}
+		if (lost_town_hall) {
+			player.LostMainFacilityTimer = GameCycle + (30 * CYCLES_PER_SECOND); //30 seconds until being revealed
+			for (int j = 0; j < NumPlayers; ++j) {
+				if (player.Index != j && Players[j].Type != PlayerNobody) {
+					Players[j].Notify(_("%s has lost their last base, and will be revealed in thirty seconds!"), player.Name.c_str());
+				} else {
+					Players[j].Notify("%s", _("You have lost your last base, and will be revealed in thirty seconds!"));
+				}
+			}
+		}
+	}
+
 	//  Handle order cancels.
 	unit.CurrentOrder()->Cancel(unit);
 
@@ -1652,6 +1672,7 @@ bool CUnit::IsVisible(const CPlayer &player) const
 			}
 		}
 	}
+
 	return false;
 }
 
@@ -1669,7 +1690,9 @@ bool CUnit::IsVisibleOnMinimap() const
 	if (IsInvisibile(*ThisPlayer)) {
 		return false;
 	}
-	if (IsVisible(*ThisPlayer) || ReplayRevealMap || IsVisibleOnRadar(*ThisPlayer)) {
+	if (IsVisible(*ThisPlayer) || ReplayRevealMap || IsVisibleOnRadar(*ThisPlayer) 
+		|| (CPlayer::IsRevelationEnabled() && Player->IsRevealed() 
+			&& (CPlayer::RevelationFor == CPlayer::cAllUnits || this->Type->BoolFlag[BUILDING_INDEX].value))) {
 		return IsAliveOnMap();
 	} else {
 		return Type->BoolFlag[VISIBLEUNDERFOG_INDEX].value && Seen.State != 3


### PR DESCRIPTION
Units of revealed players will appear in the minimap. 
Mostly need in the end of game, in cases when enemy units spread out across map and you have to find all of them to finish this game.

If enabled, there is two options "Reveal all units" (set by default) and "Reveal only buildings" (added for future use). Which can be selected in the stratagus.lua by calling `SetRevelationType()`.
Loosing last Town Hall triggered timer, an if player will not start build another TH he will be revealed.