### PR TITLE
Handle SDL2 window resize events.

### DIFF
--- a/src/video/sdl.cpp
+++ b/src/video/sdl.cpp
@@ -539,6 +539,11 @@ static void SdlDoEvent(const EventCallback &callbacks, SDL_Event &event)
 				}
 				}
 				break;
+				case SDL_WINDOWEVENT_RESIZED:
+					Video.WindowWidth = Video.Width = event.window.data1;
+					Video.WindowHeight = Video.Height = event.window.data2;
+					Video.ResizeScreen(Video.Width, Video.Height);
+				break;
 			}
 			break;
 


### PR DESCRIPTION
This allows using maximum screen space.

I've also assigned the changed dimensions to WindowHeight & WindowWidth, but I do wonder whether those two member vars are needed at all. But that'd be a separate issue..