### PR TITLE
Removed wrong enum class values comparation.

### DIFF
--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -338,9 +338,7 @@ int PlayerColorIndexCount;
 */
 void CPlayer::SetRevelationType(const RevealTypes type)
 {
-	if (type >= RevealTypes::cNoRevelation && type <= RevealTypes::cBuildingsOnly) {
-		CPlayer::RevelationFor = type;
-	}
+	CPlayer::RevelationFor = type;
 }
 
 /**


### PR DESCRIPTION
Because of C++11's enum class doesn't guarantee contiguous values (unlike C++03's enum) this condition check has no sense.