### PR TITLE
Fixed Access Violation on Windows 10 (x64)

### DIFF
--- a/src/stratagus/iolib.cpp
+++ b/src/stratagus/iolib.cpp
@@ -715,8 +715,8 @@ int ReadDataDirectory(const char *dirname, std::vector<FileList> &fl)
 #else
 	strcat_s(buffer, sizeof(buffer), "*.*");
 	struct _finddata_t fileinfo;
-	long hFile = _findfirst(buffer, &fileinfo);
-	if (hFile != -1L) {
+	intptr_t hFile = _findfirst(buffer, &fileinfo);
+	if (hFile != -1) {
 		do {
 			filename = fileinfo.name;
 #endif


### PR DESCRIPTION
hFile should be defined as intptr_t to resolve 0xC0000005: Access Violation in ntdll.dll, as per https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/findnext-functions?redirectedfrom=MSDN&view=vs-2019