### PR TITLE
Adding two commands in CclOrderUnit

### DIFF
--- a/src/unit/script_unit.cpp
+++ b/src/unit/script_unit.cpp
@@ -859,6 +859,10 @@ static int CclOrderUnit(lua_State *l)
 			if (plynr == -1 || plynr == unit.Player->Index) {
 				if (!strcmp(order, "move")) {
 					CommandMove(unit, (dpos1 + dpos2) / 2, 1);
+				} else if (!strcmp(order, "stop")) {
+					CommandStopUnit(unit); //Stop the unit
+				} else if (!strcmp(order, "stand-ground")) {
+					CommandStandGround(unit,0); //Stand and flush every order
 				} else if (!strcmp(order, "attack")) {
 					CUnit *attack = TargetOnMap(unit, dpos1, dpos2);
 					CommandAttack(unit, (dpos1 + dpos2) / 2, attack, 1);


### PR DESCRIPTION
I was playing around with the <u>Wargus editor</u> and I found a specific Lua script where I can specify some orders to give to the units inside the <u>.sms</u> files. So I was searching for the commands **stop** and **stand-ground** but every time I tried to give those orders I got this error:

`/build/stratagus-A5HbDh/stratagus-3.0.0/src/unit/script_unit.cpp:870: CclOrderUnit: Unsupported order: stand-ground`

So I have found the commands inside the **commands.cpp** file and I simply added these two commands in the **CclOrderUnit** static function.