### PR TITLE
Fixed the LuaCheckArgs in CclShowMapLocation

### DIFF
--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -184,7 +184,7 @@ static int CclShowMapLocation(lua_State *l)
 	// Put a unit on map, use its properties, except for
 	// what is listed below
 
-	LuaCheckArgs(l, 4);
+	LuaCheckArgs(l, 5);
 	const char *unitname = LuaToString(l, 5);
 	CUnitType *unitType = UnitTypeByIdent(unitname);
 	if (!unitType) {


### PR DESCRIPTION
From the [issue](https://github.com/Wargus/stratagus/issues/318) I have written today the problem of why the function ShowMapLocation don't work it's because the number of arguments passed through LuaCheckArgs were 4 instead of 5 like it is indicated in the [documentation](https://htmlpreview.github.io/?https://raw.githubusercontent.com/Wargus/stratagus/master/doc/scripts/game.html#ShowMapLocation).