### PR TITLE
Fix/resources gathering

### DIFF
--- a/src/action/action_resource.cpp
+++ b/src/action/action_resource.cpp
@@ -1065,11 +1065,13 @@ bool COrder_Resource::WaitInDepot(CUnit &unit)
 			return false;
 		}
 	} else {
+		/// FIXME: Make it customizable
 		const unsigned int tooManyWorkers = 15;
+
 		CUnit *mine = this->Resource.Mine;
 		const int range = 15;
-		CUnit *newdepot = NULL;
-		CUnit *goal = NULL;
+		CUnit *newdepot = nullptr;
+		CUnit *goal = nullptr;
 		const bool longWay = unit.pathFinderData->output.Cycles > 500;
 
 		if (unit.Player->AiEnabled && AiPlayer && AiPlayer->BuildDepots) {
@@ -1086,8 +1088,20 @@ bool COrder_Resource::WaitInDepot(CUnit &unit)
 
 		// If goal is not NULL, then we got it in AiGetSuitableDepot
 		if (!goal) {
-			goal = UnitFindResource(unit, newdepot ? *newdepot : (mine ? *mine : unit), mine ? range : 1000,
-									this->CurrentResource, unit.Player->AiEnabled, newdepot ? newdepot : depot);
+			if (mine != nullptr && mine->IsAlive()) {
+			goal = mine;
+			} else {
+				const CUnit *start_unit = nullptr;
+				if (newdepot != nullptr) {
+					start_unit = newdepot;
+				} else if (depot != nullptr) {
+					start_unit = depot;
+				}
+				goal = UnitFindResource(unit, (start_unit ? *start_unit : unit), 1000, this->CurrentResource, 
+										unit.Player->AiEnabled, (newdepot ? newdepot : depot));
+			}
+
+									
 		}
 
 		if (goal) {

--- a/src/action/action_resource.cpp
+++ b/src/action/action_resource.cpp
@@ -119,7 +119,6 @@ static bool FindNearestReachableTerrainType(int movemask, int resmask, int range
 	terrainTraversal.SetSize(Map.Info.MapWidth, Map.Info.MapHeight);
 	terrainTraversal.Init();
 
-	Assert(Map.Field(startPos)->CheckMask(resmask));
 	terrainTraversal.PushPos(startPos);
 
 	NearReachableTerrainFinder nearReachableTerrainFinder(player, range, movemask, resmask, terrainPos);

--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -1315,7 +1315,7 @@ static int SendResource(const Vec2i &pos)
 					if (unit.Type->ResInfo[res]
 						&& unit.Type->ResInfo[res]->TerrainHarvester
 						&& mf.playerInfo.IsExplored(*unit.Player)
-						&& mf.IsTerrainResourceOnMap(res)
+					  /*&& mf.IsTerrainResourceOnMap(res)*/
 						&& unit.ResourcesHeld < unit.Type->ResInfo[res]->ResourceCapacity
 						&& (unit.CurrentResource != res || unit.ResourcesHeld < unit.Type->ResInfo[res]->ResourceCapacity)) {
 						SendCommandResourceLoc(unit, pos, flush);

--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -1315,7 +1315,8 @@ static int SendResource(const Vec2i &pos)
 					if (unit.Type->ResInfo[res]
 						&& unit.Type->ResInfo[res]->TerrainHarvester
 						&& mf.playerInfo.IsExplored(*unit.Player)
-					  /*&& mf.IsTerrainResourceOnMap(res)*/
+						/// By disabling this, we allow the harvester to find the nearest tile with a resource by itself, in case mf is empty.
+						/*&& mf.IsTerrainResourceOnMap(res)*/ 
 						&& unit.ResourcesHeld < unit.Type->ResInfo[res]->ResourceCapacity
 						&& (unit.CurrentResource != res || unit.ResourcesHeld < unit.Type->ResInfo[res]->ResourceCapacity)) {
 						SendCommandResourceLoc(unit, pos, flush);


### PR DESCRIPTION
- Removed wrong assertion. Fixes this: https://github.com/Wargus/stratagus/issues/322
- When returning from a depot to gather resources, use the same mine as before if it is still alive; otherwise, search for a resource unit as close to the depot as possible
- Enabled 'H'-click for resources gathering (when click on the empty tile unit will find nearest to this pos resource).
- Enabled 'Harvest" rally-point for Town Halls: now newly produced peasant will go to gather nearest to the rally-point resources. Before, it was possible only for mines.