### PR TITLE
Add center align for UI map area in case the map completely fits into…

### DIFF
--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -169,10 +169,10 @@ public:
 	bool Contains(const PixelPos &screenPos) const;
 
 public:
-	int X;                          /// Screen pixel left corner x coordinate
-	int Y;                          /// Screen pixel upper corner y coordinate
-	int EndX;                       /// Screen pixel right x coordinate
-	int EndY;                       /// Screen pixel bottom y coordinate
+	int X;                          /// Screen pixel left corner x coordinate adjusted for current map size
+	int Y;                          /// Screen pixel upper corner y coordinate adjusted for current map size 
+	int EndX;                       /// Screen pixel right x coordinate adjusted for current map size
+	int EndY;                       /// Screen pixel bottom y coordinate adjusted for current map size
 	int ScrollPaddingLeft;          /// Scrollable area past the left of map
 	int ScrollPaddingRight;         /// Scrollable area past the right of map
 	int ScrollPaddingTop;           /// Scrollable area past the top of map

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -209,8 +209,25 @@ void InitUserInterface()
 	// Calculations
 	//
 	if (Map.Info.MapWidth) {
-		UI.MapArea.EndX = std::min<int>(UI.MapArea.EndX, UI.MapArea.X + Map.Info.MapWidth * PixelTileSize.x - 1);
-		UI.MapArea.EndY = std::min<int>(UI.MapArea.EndY, UI.MapArea.Y + Map.Info.MapHeight * PixelTileSize.y - 1);
+		/// Align UI map area if at least one of the map dimensions fits completely into it.
+		const uint16_t mapWidthInPixels = Map.Info.MapWidth * PixelTileSize.x;
+		const uint16_t mapHeightInPixels = Map.Info.MapHeight * PixelTileSize.y;
+		const uint16_t uiMapAreaWidth = UI.MapArea.EndX - UI.MapArea.X;
+		const uint16_t uiMapAreaHeight = UI.MapArea.EndY - UI.MapArea.Y;
+		uint16_t xAlign = 0;
+		uint16_t yAlign = 0;
+		
+		if (mapWidthInPixels < uiMapAreaWidth) {
+			xAlign = (uiMapAreaWidth - mapWidthInPixels) / 2;
+			UI.MapArea.X += xAlign;
+		}	
+		if (mapHeightInPixels < uiMapAreaHeight) {
+			yAlign = (uiMapAreaHeight - mapHeightInPixels) / 2;
+			UI.MapArea.Y += yAlign;
+		}
+
+		UI.MapArea.EndX = std::min<int>(UI.MapArea.EndX - xAlign, UI.MapArea.X + Map.Info.MapWidth * PixelTileSize.x - 1);
+		UI.MapArea.EndY = std::min<int>(UI.MapArea.EndY - yAlign, UI.MapArea.Y + Map.Info.MapHeight * PixelTileSize.y - 1);
 	}
 
 	UI.SelectedViewport = UI.Viewports;


### PR DESCRIPTION
… it by at least one of the dimensions.
In-game and window resolution the same: 1706x1280
Map size: 32x32

before:
![image](https://user-images.githubusercontent.com/5509477/111909059-c750e280-8a6c-11eb-9291-7018a021a1ca.png)

after:
![image](https://user-images.githubusercontent.com/5509477/111909068-cd46c380-8a6c-11eb-995c-9ff0fb6353da.png)
