### PR TITLE
Shadowcasting field of view + enhanced fog of war.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,12 +7,18 @@
             "linux": {
               "program": "${workspaceFolder}/build/stratagus-dbg",
               "args": ["-W", "-a", "-d", "${workspaceFolder}/../data.${input:game}"],
+              "environment": [
+                {"name": "OMP_WAIT_POLICY", "value": "passive"}
+              ],
             },
             "windows": {
               "type": "cppvsdbg",
               "program": "${workspaceFolder}/build/Debug/stratagus.exe",
               "args": ["-W", "-a", "-d", "${workspaceFolder}\\..\\data.${input:game}"],
-              "environment": [{"name": "PATH", "value": "${workspaceFolder}\\..\\dependencies\\bin;${env:PATH}"}],
+              "environment": [
+                {"name": "PATH", "value": "${workspaceFolder}\\..\\dependencies\\bin;${env:PATH}"},
+                {"name": "OMP_WAIT_POLICY", "value": "passive"}
+              ],
               "externalConsole": true,
             },
             "stopAtEntry": false,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ source_group(guichan FILES ${guichan_SRCS})
 set(map_SRCS
 	src/map/fov.cpp
 	src/map/fow.cpp
+	src/map/fow_utils.cpp
 	src/map/map.cpp
 	src/map/map_draw.cpp
 	src/map/map_fog.cpp
@@ -532,6 +533,7 @@ set(stratagus_generic_HDRS
 	src/include/font.h
 	src/include/fov.h
 	src/include/fow.h
+	src/include/fow_utils.h
 	src/include/game.h
 	src/include/icons.h
 	src/include/interface.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,6 +649,7 @@ find_package(SDL2_mixer REQUIRED)
 find_package(SDL2_image REQUIRED)
 find_package(Tolua++ REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(OpenMP)
 
 if(WIN32)
 	find_package(MakeNSIS)
@@ -1075,6 +1076,12 @@ else ()
    add_executable(stratagus ${stratagus_SRCS} ${stratagus_HDRS})
 endif ()
 target_link_libraries(stratagus ${stratagus_LIBS})
+
+if(OpenMP_CXX_FOUND)
+	target_compile_options(stratagus PRIVATE ${OpenMP_CXX_FLAGS})
+	target_link_libraries(stratagus OpenMP::OpenMP_CXX)
+endif()
+
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	set_target_properties(stratagus PROPERTIES OUTPUT_NAME stratagus-dbg)

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -47,7 +47,6 @@
     <li>Optimized shared vison code.</li>
     <li>Now field of view parameters and auto targeting algorithm can be changed simultaneously for all computers of already started network game. It prevents desync causes. Mostly useful for debug.</li>
     <li>Map grid is optional now and can be disabled. Actual only for debug builds.</li>
-    <li>Added ingame "debug menu". Among other things it allows to change FOV parameters on the fly. Enabled only for debug builds.</li>
     <li>Added enhanced type of fog of war, as long as original sprite-based fog can't be used when shadow caster is enabled. Also added few parameters to tune it (blur radius, number of blur iterations, number fog easing steps, bilinear interpolation).</li>
     <li>Added "elevated" flag for units/buildings which can look over opaque fields (f.eg. towers).</li>
     <li>Implemented shadow caster field of view type, which blocks vision through opaque obstacles (f.eg. cave walls in war1gus) or certain map tiles with enabled "opaque" flag. In additional there is a possibility to enable opacity for all rocks- OR forest- OR wall-tiles. This feature makes it possible to implement sight blocking for high/low ground .</li>

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -41,6 +41,17 @@
 <ul>
 <p/>
 <p/>
+<li>3.1.0 Unreleases<p/></li>
+  <ul>
+    <li></li>
+    <li>Optimized shared vison code.</li>
+    <li>Now field of view parameters and auto targeting algorithm can be changed simultaneously for all computers of already started network game. It prevents desync causes. Mostly useful for debug.</li>
+    <li>Map grid is optional now and can be disabled. Actual only for debug builds.</li>
+    <li>Added ingame "debug menu". Among other things it allows to change FOV parameters on the fly. Enabled only for debug builds.</li>
+    <li>Added enhanced type of fog of war, as long as original sprite-based fog can't be used when shadow caster is enabled. Also added few parameters to tune it (blur radius, number of blur iterations, number fog easing steps, bilinear interpolation).</li>
+    <li>Added "elevated" flag for units/buildings which can look over opaque fields (f.eg. towers).</li>
+    <li>Implemented shadow caster field of view type, which blocks vision through opaque obstacles (f.eg. cave walls in war1gus) or certain map tiles with enabled "opaque" flag. In additional there is a possibility to enable opacity for all rocks- OR forest- OR wall-tiles. This feature makes it possible to implement sight blocking for high/low ground .</li>
+  </ul>
 <li>3.0.0 Released<p/></li>
   <ul>
     <li>Migrate to SDL2, remove old direct OpenGL backend</li>

--- a/gameheaders/stratagus-game-launcher.h
+++ b/gameheaders/stratagus-game-launcher.h
@@ -668,7 +668,7 @@ int main(int argc, char * argv[]) {
     environ[i] = (char*)"OMP_WAIT_POLICY=passive";
     environ[i + 1] = NULL;
 #ifdef WIN32
-	int ret = _spawnvp(_P_WAIT, stratagus_bin, stratagus_argv);
+	int ret = _spawnvpe(_P_WAIT, stratagus_bin, stratagus_argv, environ);
 #else
 	int ret = 0;
 	int childpid = fork();

--- a/gameheaders/stratagus-game-launcher.h
+++ b/gameheaders/stratagus-game-launcher.h
@@ -662,15 +662,18 @@ int main(int argc, char * argv[]) {
 	stratagus_argv[argc + 2] = NULL;
 
 	// Needed to reduce CPU load while idle threads are wating for havn't finished yet ones
-	char *const env[] = { (char*)"OMP_WAIT_POLICY=passive", NULL }; 
-
+	extern char** environ;
+    int i = 0;
+    while(environ[i]) { i++; }
+    environ[i] = (char*)"OMP_WAIT_POLICY=passive";
+    environ[i + 1] = NULL;
 #ifdef WIN32
-	int ret = _spawnvpe(_P_WAIT, stratagus_bin, stratagus_argv, env);
+	int ret = _spawnvp(_P_WAIT, stratagus_bin, stratagus_argv);
 #else
 	int ret = 0;
 	int childpid = fork();
 	if (childpid == 0) {
-		execvpe(stratagus_bin, stratagus_argv, env);
+		execvp(stratagus_bin, stratagus_argv);
 		if (strcmp(stratagus_bin, "stratagus") == 0) {
 			realpath(argv[0], stratagus_bin);
 			parentdir(stratagus_bin);

--- a/gameheaders/stratagus-game-launcher.h
+++ b/gameheaders/stratagus-game-launcher.h
@@ -661,13 +661,16 @@ int main(int argc, char * argv[]) {
 	}
 	stratagus_argv[argc + 2] = NULL;
 
+	// Needed to reduce CPU load while idle threads are wating for havn't finished yet ones
+	char *const env[] = { (char*)"OMP_WAIT_POLICY=passive", NULL }; 
+
 #ifdef WIN32
-	int ret = _spawnvp(_P_WAIT, stratagus_bin, stratagus_argv);
+	int ret = _spawnvpe(_P_WAIT, stratagus_bin, stratagus_argv, env);
 #else
 	int ret = 0;
 	int childpid = fork();
 	if (childpid == 0) {
-		execvp(stratagus_bin, stratagus_argv);
+		execvpe(stratagus_bin, stratagus_argv, env);
 		if (strcmp(stratagus_bin, "stratagus") == 0) {
 			realpath(argv[0], stratagus_bin);
 			parentdir(stratagus_bin);

--- a/src/action/action_resource.cpp
+++ b/src/action/action_resource.cpp
@@ -10,7 +10,7 @@
 //
 /**@name action_resource.cpp - The generic resource action. */
 //
-//      (c) Copyright 2001-2005 by Crestez Leonard and Jimmy Salmon
+//      (c) Copyright 2001-2021 by Crestez Leonard and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/action/action_resource.cpp
+++ b/src/action/action_resource.cpp
@@ -10,7 +10,7 @@
 //
 /**@name action_resource.cpp - The generic resource action. */
 //
-//      (c) Copyright 2001-2021 by Crestez Leonard and Jimmy Salmon
+//      (c) Copyright 2001-2005 by Crestez Leonard and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/action/command.cpp
+++ b/src/action/command.cpp
@@ -10,7 +10,7 @@
 //
 /**@name command.cpp - Give units a command. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/action/command.cpp
+++ b/src/action/command.cpp
@@ -915,6 +915,7 @@ void CommandDiplomacy(int player, int state, int opponent)
 */
 void CommandSharedVision(int player, bool state, int opponent)
 {
+	
 	// Do a real hardcore seen recount. First we unmark EVERYTHING.
 	for (CUnitManager::Iterator it = UnitManager.begin(); it != UnitManager.end(); ++it) {
 		CUnit &unit = **it;
@@ -923,31 +924,24 @@ void CommandSharedVision(int player, bool state, int opponent)
 		}
 	}
 
-	// Compute Before and after.
-	const int before = Players[player].HasMutualSharedVisionWith(Players[opponent]);
+	// Compute Before.
+	const bool before = Players[player].HasSharedVisionWith(Players[opponent]);
 	if (state == false) {
 		Players[player].UnshareVisionWith(Players[opponent]);
 	} else {
 		Players[player].ShareVisionWith(Players[opponent]);
 	}
-	const int after = Players[player].HasMutualSharedVisionWith(Players[opponent]);
 
-	if (before && !after) {
-		// Don't share vision anymore. Give each other explored terrain for good-bye.
-
-		for (int i = 0; i != Map.Info.MapWidth * Map.Info.MapHeight; ++i) {
+	if (before && !state) {
+		// Don't share vision anymore. Give explored terrain for good-bye.
+		const size_t fieldsNum = Map.Info.MapWidth * Map.Info.MapHeight;
+		for (size_t i = 0; i != fieldsNum; ++i) {
 			CMapField &mf = *Map.Field(i);
 			CMapFieldPlayerInfo &mfp = mf.playerInfo;
 
 			if (mfp.Visible[player] && !mfp.Visible[opponent]) {
 				mfp.Visible[opponent] = 1;
 				if (opponent == ThisPlayer->Index) {
-					Map.MarkSeenTile(mf);
-				}
-			}
-			if (mfp.Visible[opponent] && !mfp.Visible[player]) {
-				mfp.Visible[player] = 1;
-				if (player == ThisPlayer->Index) {
 					Map.MarkSeenTile(mf);
 				}
 			}
@@ -961,6 +955,7 @@ void CommandSharedVision(int player, bool state, int opponent)
 			MapMarkUnitSight(unit);
 		}
 	}
+
 }
 
 /**

--- a/src/action/command.cpp
+++ b/src/action/command.cpp
@@ -10,7 +10,7 @@
 //
 /**@name command.cpp - Give units a command. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/editor/editloop.cpp
+++ b/src/editor/editloop.cpp
@@ -10,7 +10,7 @@
 //
 /**@name editloop.cpp - The editor main loop. */
 //
-//      (c) Copyright 2002-2021 by Lutz Sammer, Jimmy Salmon and
+//      (c) Copyright 2002-2015 by Lutz Sammer, Jimmy Salmon and
 //		Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/editor/editloop.cpp
+++ b/src/editor/editloop.cpp
@@ -10,7 +10,7 @@
 //
 /**@name editloop.cpp - The editor main loop. */
 //
-//      (c) Copyright 2002-2015 by Lutz Sammer, Jimmy Salmon and
+//      (c) Copyright 2002-2021 by Lutz Sammer, Jimmy Salmon and
 //		Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/game/loadgame.cpp
+++ b/src/game/loadgame.cpp
@@ -10,7 +10,7 @@
 //
 /**@name loadgame.cpp - Load game. */
 //
-//      (c) Copyright 2001-2006 by Lutz Sammer, Andreas Arens
+//      (c) Copyright 2001-2021 by Lutz Sammer, Andreas Arens
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/game/loadgame.cpp
+++ b/src/game/loadgame.cpp
@@ -99,7 +99,7 @@ void CleanModules()
 	CleanDependencies();
 	CleanButtons();
 	CleanMissileTypes();
-	Map.Clean();
+	Map.Clean(true);
 	CParticleManager::exit();
 	CleanReplayLog();
 	CleanSpells();

--- a/src/game/loadgame.cpp
+++ b/src/game/loadgame.cpp
@@ -10,7 +10,7 @@
 //
 /**@name loadgame.cpp - Load game. */
 //
-//      (c) Copyright 2001-2021 by Lutz Sammer, Andreas Arens
+//      (c) Copyright 2001-2006 by Lutz Sammer, Andreas Arens
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/game/loadgame.cpp
+++ b/src/game/loadgame.cpp
@@ -100,7 +100,6 @@ void CleanModules()
 	CleanButtons();
 	CleanMissileTypes();
 	Map.Clean();
-	Map.CleanFogOfWar();
 	CParticleManager::exit();
 	CleanReplayLog();
 	CleanSpells();

--- a/src/include/fov.h
+++ b/src/include/fov.h
@@ -46,12 +46,6 @@ enum class FieldOfViewTypes { cShadowCasting,  cSimpleRadial, NumOfTypes };
 class CFieldOfView
 {
 public:
-	CFieldOfView() : currTilePos(0, 0), currOctant(0), Origin(0, 0), OpaqueFields(0),
-		Player(nullptr), Unit(nullptr), map_setFoV(nullptr)
-	{
-		Settings.FoV_Type      = FieldOfViewTypes::cSimpleRadial;
-		Settings.OpaqueFields  = MapFieldOpaque;
-	}
 	void Clean()
 	{
 		MarkedTilesCache.clear();
@@ -116,17 +110,18 @@ private:
 private:
 	struct FieldOfViewSettings 
 	{
-		FieldOfViewTypes FoV_Type;        /// Type of field of view - Shadowcasting or Simple Radial
-		uint16_t 		 OpaqueFields;    /// Flags for opaque MapFields
+		FieldOfViewTypes Type	  	  {FieldOfViewTypes::cSimpleRadial}; 	/// Type of field of view - Shadowcasting or Simple Radial
+		uint16_t 		 OpaqueFields {MapFieldOpaque};    				/// Flags for opaque MapFields
 	} Settings;
 
-	Vec2i            currTilePos;       /// Current work tile pos in global (Map) system coordinates
-	char		 	 currOctant;        /// Current octant
-	Vec2i		 	 Origin;            /// Position of the spectator in the global (Map) coordinate system
-	unsigned short   OpaqueFields;      /// Flags for opaque MapTiles for current calculation
-	const CPlayer   *Player;			/// Pointer to player to set FoV for
-	const CUnit     *Unit;				/// Pointer to unit to calculate FoV for
-	MapMarkerFunc	*map_setFoV;        /// Pointer to external function for setting tiles visibilty
+	Vec2i            currTilePos  {0, 0};	/// Current work tile pos in global (Map) system coordinates
+	char		 	 currOctant   {0};		/// Current octant
+	Vec2i		 	 Origin 	  {0, 0};	/// Position of the spectator in the global (Map) coordinate system
+	unsigned short   OpaqueFields {0};		/// Flags for opaque MapTiles for current calculation
+	
+	const CPlayer   *Player 	  {nullptr};	/// Pointer to player to set FoV for
+	const CUnit     *Unit 		  {nullptr};	/// Pointer to unit to calculate FoV for
+	MapMarkerFunc	*map_setFoV   {nullptr};	/// Pointer to external function for setting tiles visibilty
 
 	std::vector<uint8_t> MarkedTilesCache;	/// To prevent multiple calls of map_setFoV for single tile (for tiles on the vertical,
 											/// horizontal and diagonal lines it calls twise) we use cache table to 

--- a/src/include/fov.h
+++ b/src/include/fov.h
@@ -52,8 +52,8 @@ public:
 	}
 
 	/// Refresh field of view
-	void Refresh(const CPlayer &player, const CUnit &unit, const Vec2i &pos, const short width, 
-				const short height, const short range, MapMarkerFunc *marker);
+	void Refresh(const CPlayer &player, const CUnit &unit, const Vec2i &pos, const uint16_t width, 
+				 const uint16_t height, const uint16_t range, MapMarkerFunc *marker);
 
 	bool SetType(const FieldOfViewTypes fov_type);
 	FieldOfViewTypes GetType() const;
@@ -68,29 +68,30 @@ protected:
 private:
 	/// Struct for portion of column. Used in FoV calculations
 	struct SColumnPiece {
-		SColumnPiece(short xValue, Vec2i top, Vec2i bottom) : col(xValue), TopVector(top), BottomVector(bottom) {}
-		short col;
+		SColumnPiece(int16_t xValue, Vec2i top, Vec2i bottom) : col(xValue), TopVector(top), BottomVector(bottom) {}
+		int16_t col;
 		Vec2i TopVector;
 		Vec2i BottomVector;
 	};
 
 	/// Calc whole simple radial field of view
-	void ProceedSimpleRadial(const CPlayer &player, const Vec2i &pos, const int w, const int h, int range, MapMarkerFunc *marker) const;
+	void ProceedSimpleRadial(const CPlayer &player, const Vec2i &pos, const int16_t w, const int16_t h, 
+							 int16_t range, MapMarkerFunc *marker) const;
 	/// Calc whole chadow casting field of view
-	void ProceedShadowCasting(const Vec2i &spectatorPos, const short width, const short height, const short range);
+	void ProceedShadowCasting(const Vec2i &spectatorPos, const uint16_t width, const uint16_t height, const uint16_t range);
 	/// Calc field of view for set of lines along x or y. 
 	/// Used for calc part of FoV for assymetric (widht != height) spectators.
-	void ProceedRaysCast(const char octant, const Vec2i &origin, const short width, const short range);
+	void ProceedRaysCast(const uint8_t octant, const Vec2i &origin, const uint16_t width, const uint16_t range);
 	/// Calc shadow casting field of view for single octant
-	void RefreshOctant(const char octant, const Vec2i &origin, const short range);
+	void RefreshOctant(const uint8_t octant, const Vec2i &origin, const uint16_t range);
 	/// Calc shadow casting for portion of column 
-	void CalcFoVForColumnPiece(const short col, Vec2i &topVector, Vec2i &bottomVector,
-							   const short range, std::queue<SColumnPiece> &wrkQueue);
+	void CalcFoVForColumnPiece(const int16_t col, Vec2i &topVector, Vec2i &bottomVector,
+							   const uint16_t range, std::queue<SColumnPiece> &wrkQueue);
 	/// Recalculate top or bottom direction vectors
-	short CalcRow_ByVector(const bool isTop, const short x, const Vec2i &vector) const;
+	int16_t CalcRow_ByVector(const bool isTop, const int16_t x, const Vec2i &vector) const;
 
 	/// Recalculate coordinates and set current MapTile for [col, row]
-	bool SetCurrentTile(const short col, const short row);
+	bool SetCurrentTile(const int16_t col, const int16_t row);
 	/// Check if current MapTile opaque
 	bool IsTileOpaque() const;
 	/// Mark current MapTile
@@ -99,13 +100,13 @@ private:
 	/// Setup ShadowCaster for current refreshing of FoV
 	void PrepareShadowCaster(const CPlayer &player, const CUnit &unit, const Vec2i &pos, MapMarkerFunc *marker);
 	void ResetShadowCaster();
-	void PrepareCache(const Vec2i pos, const short width, const short height, const short range);
+	void PrepareCache(const Vec2i pos, const uint16_t width, const uint16_t height, const uint16_t range);
 
 	/// Update values of Octant and Origin for current working set
-	void SetEnvironment(const char octant, const Vec2i &origin);
+	void SetEnvironment(const uint8_t octant, const Vec2i &origin);
 	void ResetEnvironment();
 	/// Project [col,row] coordinates from current octant to global (Map) coordinate system and accordingly update position of current MapTile
-	void ProjectCurrentTile(const short col, const short row);
+	void ProjectCurrentTile(const int16_t col, const int16_t row);
 
 private:
 	struct FieldOfViewSettings 
@@ -115,9 +116,9 @@ private:
 	} Settings;
 
 	Vec2i            currTilePos  {0, 0};	/// Current work tile pos in global (Map) system coordinates
-	char		 	 currOctant   {0};		/// Current octant
+	uint8_t		 	 currOctant   {0};		/// Current octant
 	Vec2i		 	 Origin 	  {0, 0};	/// Position of the spectator in the global (Map) coordinate system
-	unsigned short   OpaqueFields {0};		/// Flags for opaque MapTiles for current calculation
+	uint16_t		 OpaqueFields {0};		/// Flags for opaque MapTiles for current calculation
 	
 	const CPlayer   *Player 	  {nullptr};	/// Pointer to player to set FoV for
 	const CUnit     *Unit 		  {nullptr};	/// Pointer to unit to calculate FoV for
@@ -138,7 +139,7 @@ extern CFieldOfView FieldOfView;
 --  Functions
 ----------------------------------------------------------------------------*/
 
-inline bool CFieldOfView::SetCurrentTile(const short col, const short row)
+inline bool CFieldOfView::SetCurrentTile(const int16_t col, const int16_t row)
 {
 	ProjectCurrentTile(col, row);
 	if (Map.Info.IsPointOnMap(currTilePos.x, currTilePos.y)) {
@@ -164,7 +165,7 @@ inline void CFieldOfView::MarkTile()
 	} 
 }
 
-inline void CFieldOfView::ProjectCurrentTile(const short col, const short row)
+inline void CFieldOfView::ProjectCurrentTile(const int16_t col, const int16_t row)
 {
 	switch (currOctant) {
 		case 1:  currTilePos.x =  row; currTilePos.y =  col; break;

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -109,10 +109,10 @@ private:
                                               /// ThisPlayer and his allies in normal games
                                               /// Any set of players for observers and in the replays
     std::vector<uint8_t> VisTable;            /// vision table for whole map + 1 tile around (for simplification of upscale algorithm purposes)
-    size_t               VisTable_Index0 {0}; /// index in the vision table for [0:0] tile
+    size_t               VisTable_Index0 {0}; /// index in the vision table for [0:0] map tile
     size_t               VisTableWidth   {0}; /// width of the vision table
     CEasedTexture        FogTexture;          /// Upscaled fog texture (alpha-channel values only) for whole map 
-                                              /// + 1 tile around (for simplification of upscale algorithm purposes).
+                                              /// + 1 tile to the left and up (for simplification of upscale algorithm purposes).
     std::vector<uint8_t> RenderedFog;         /// Back buffer for bilinear upscaling in to viewports
     CBlurer              Blurer;              /// Blurer for fog of war texture
 

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -68,7 +68,7 @@ private:
     void GenerateFog(const CPlayer &thisPlayer);
     void GenerateFogTexture();
 
-    uint8_t DeterminePattern(const intptr_t index, const uint8_t visFlag);
+    uint8_t DeterminePattern(const size_t index, const uint8_t visFlag);
     void FillUpscaledRec(uint32_t *texture, const int textureWidth, intptr_t index, const uint8_t patternVisible, 
                                                                                     const uint8_t patternExplored);
     void RenderToSurface(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -54,10 +54,11 @@ public:
     void Init();
     void Clean();
     bool SetType(const FogOfWarTypes fowType);
-    FogOfWarTypes GetType()   { return Settings.FOW_Type;    }
-    
-    CColor   GetFogColor()    { return Settings.FogColor;    }
-    uint32_t GetFogColorSDL() { return Settings.FogColorSDL; }
+
+    FogOfWarTypes GetType()   const { return Settings.FOW_Type; }
+    CColor   GetFogColor()    const { return Settings.FogColor; }
+    uint32_t GetFogColorSDL() const { return Settings.FogColorSDL; }
+
     void SetFogColor(uint8_t r, uint8_t g, uint8_t b);
     void SetFogColor(CColor color);
 
@@ -71,13 +72,15 @@ private:
     void GenerateFog(const CPlayer &thisPlayer);
     void FogUpscale4x4();
 
-    uint8_t DeterminePattern(const size_t index, const uint8_t visFlag);
-    void FillUpscaledRec(uint32_t *texture, const int textureWidth, intptr_t index, const uint8_t patternVisible, 
-                                                                                    const uint8_t patternExplored);
+    uint8_t DeterminePattern(const size_t index, const uint8_t visFlag) const;
+    void FillUpscaledRec(uint32_t *texture, const uint16_t textureWidth, size_t index, 
+                         const uint8_t patternVisible, const uint8_t patternExplored) const;
+
     void UpscaleBilinear(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
+                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect) const;
+
     void UpscaleSimple(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                       SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
+                       SDL_Surface *const trgSurface, const SDL_Rect &trgRect) const;
     
 public:
 

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -97,7 +97,7 @@ private:
         uint8_t       NumOfEasingSteps {8};
         float         BlurRadius       {2};
         uint8_t       BlurIterations   {3};
-        uint8_t       UpscaleType      {UpscaleTypes::cSimple};
+        uint8_t       UpscaleType      {UpscaleTypes::cBilinear};
 	} Settings;
 
     uint8_t State { States::cFirstEntry };

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -48,6 +48,7 @@ public:
     static void Init();
     static void Init(const float radius, const uint8_t numOfIterations);
     void Setup(const uint16_t textureWidth, const uint16_t textureHeight);
+    void Clean();
     void Blur(uint8_t *texture);
 private:
     void ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t radius);

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -10,7 +10,7 @@
 //
 /**@name fow.h - The fog of war headerfile. */
 //
-//      (c) Copyright 2021 Alyokhin
+//      (c) Copyright 2020-2021 by Alyokhin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by
@@ -50,14 +50,13 @@ public:
     enum VisionType   { cUnseen  = 0, cExplored = 0b001, cVisible = 0b010 };
     enum States       { cFirstEntry = 0, cGenerateFog, cGenerateTexture, cBlurTexture, cReady };
     enum UpscaleTypes { cSimple = 0, cBilinear };
-
-
     
     void Init();
     void Clean();
-    bool SetType(const FogOfWarTypes fow_type);
+    bool SetType(const FogOfWarTypes fowType);
     FogOfWarTypes GetType()   { return Settings.FOW_Type;    }
-    CColor GetFogColor()      { return Settings.FogColor;    }
+    
+    CColor   GetFogColor()    { return Settings.FogColor;    }
     uint32_t GetFogColorSDL() { return Settings.FogColorSDL; }
     void SetFogColor(uint8_t r, uint8_t g, uint8_t b);
     void SetFogColor(CColor color);
@@ -66,22 +65,19 @@ public:
     void InitBlurer(const float radius1, const float radius2, const uint16_t numOfIterations);
 
     void Update(bool doAtOnce = false);
-    void RenderToViewPort(const CViewport &viewport, SDL_Surface *const vpSurface);
+    void GetFogForViewport(const CViewport &viewport, SDL_Surface *const vpSurface);
 
 private:
     void GenerateFog(const CPlayer &thisPlayer);
-    void GenerateFogTexture();
+    void FogUpscale4x4();
 
     uint8_t DeterminePattern(const size_t index, const uint8_t visFlag);
     void FillUpscaledRec(uint32_t *texture, const int textureWidth, intptr_t index, const uint8_t patternVisible, 
                                                                                     const uint8_t patternExplored);
-    void RenderToSurface(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         const SDL_Rect &trgRect, SDL_Surface *const renderSurface, const SDL_Rect &renderRect, const PixelDiff &offset);
     void UpscaleBilinear(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         const SDL_Rect &trgRect, SDL_Surface *const renderSurface, const SDL_Rect &renderRect, const PixelDiff &offset);
-    void UpscaleSimple(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         const SDL_Rect &trgRect, SDL_Surface *const renderSurface, const SDL_Rect &renderRect, const PixelDiff &offset);
-    void ApplyFogTo(uint32_t &pixel, const uint8_t alpha);
+                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
+    void UpscaleSimple(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
+                       SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
     
 public:
 
@@ -91,8 +87,8 @@ private:
 		FogOfWarTypes FOW_Type         {FogOfWarTypes::cEnhanced}; /// Type of fog of war - legacy or enhanced(smooth)
         uint8_t       NumOfEasingSteps {8};                        /// Number of the texture easing steps
         float         BlurRadius[2]    {2.0, 1.5};                 /// Radiuses or standard deviation
-        uint8_t       BlurIterations   {3};                        /// Radius or standard deviation
-        uint8_t       UpscaleType      {UpscaleTypes::cBilinear};  /// Rendering zoom type
+        uint8_t       BlurIterations   {3};                        /// Number of blur iterations
+        uint8_t       UpscaleType      {UpscaleTypes::cSimple};    /// Rendering zoom type
         CColor        FogColor         {0, 0, 0, 0};               /// Fog of war color
         uint32_t      FogColorSDL      {0};                        /// Fog of war color in the SDL format
 	} Settings;  /// Fog of war settings

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -56,8 +56,12 @@ public:
     void Init();
     void Clean();
     bool SetType(const FogOfWarTypes fow_type);
-	FogOfWarTypes GetType() { return Settings.FOW_Type; }
-    
+    FogOfWarTypes GetType()   { return Settings.FOW_Type;    }
+    CColor GetFogColor()      { return Settings.FogColor;    }
+    uint32_t GetFogColorSDL() { return Settings.FogColorSDL; }
+    void SetFogColor(uint8_t r, uint8_t g, uint8_t b);
+    void SetFogColor(CColor color);
+
     void EnableBilinearUpscale(const bool enable);
     void InitBlurer(const float radius1, const float radius2, const uint16_t numOfIterations);
 
@@ -89,7 +93,8 @@ private:
         float         BlurRadius[2]    {2.0, 1.5};                 /// Radiuses or standard deviation
         uint8_t       BlurIterations   {3};                        /// Radius or standard deviation
         uint8_t       UpscaleType      {UpscaleTypes::cBilinear};  /// Rendering zoom type
-        uint32_t      FogColor         {0};
+        CColor        FogColor         {0, 0, 0, 0};               /// Fog of war color
+        uint32_t      FogColorSDL      {0};                        /// Fog of war color in the SDL format
 	} Settings;  /// Fog of war settings
 
     uint8_t State { States::cFirstEntry };    /// State of the fog of war calculation process
@@ -101,10 +106,6 @@ private:
                                               /// + 1 tile around (for simplification of upscale algorithm purposes).
     std::vector<uint8_t> RenderedFog;         /// Back buffer for bilinear upscaling in to viewports
     CBlurer              Blurer;              /// Blurer for fog of war texture
-
-    uint8_t              FogColorR       {0};
-    uint8_t              FogColorG       {0};
-    uint8_t              FogColorB       {0};
 
     /// Table with patterns to generate fog of war texture from vision table
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -51,7 +51,7 @@ class CBlurer
 {
 public:
     static void Init();
-    static void Init(const float radius, const uint8_t numOfIterations);
+    static void Init(const float radius, const int numOfIterations);
     void Setup(const uint16_t textureWidth, const uint16_t textureHeight);
     void Clean();
     void Blur(uint8_t *texture);

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -71,13 +71,13 @@ private:
     uint8_t DeterminePattern(const intptr_t index, const uint8_t visFlag);
     void FillUpscaledRec(uint32_t *texture, const int textureWidth, intptr_t index, const uint8_t patternVisible, 
                                                                                     const uint8_t patternExplored);
-    void RenderToSurface(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect, const PixelDiff &offset, const SDL_Rect &renderRect);
-    void UpscaleBilinear(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect, const PixelDiff &offset, const SDL_Rect &renderRect);
-    void UpscaleSimple(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                       SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
-
+    void RenderToSurface(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
+                         const SDL_Rect &trgRect, SDL_Surface *const renderSurface, const SDL_Rect &renderRect, const PixelDiff &offset);
+    void UpscaleBilinear(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
+                         const SDL_Rect &trgRect, SDL_Surface *const renderSurface, const SDL_Rect &renderRect, const PixelDiff &offset);
+    void UpscaleSimple(const uint8_t *const src, const SDL_Rect &srcRect, const int16_t srcWidth,
+                         const SDL_Rect &trgRect, SDL_Surface *const renderSurface, const SDL_Rect &renderRect, const PixelDiff &offset);
+    void ApplyFogTo(uint32_t &pixel, const uint8_t alpha);
     
 public:
 
@@ -89,6 +89,7 @@ private:
         float         BlurRadius[2]    {2.0, 1.5};                 /// Radiuses or standard deviation
         uint8_t       BlurIterations   {3};                        /// Radius or standard deviation
         uint8_t       UpscaleType      {UpscaleTypes::cBilinear};  /// Rendering zoom type
+        uint32_t      FogColor         {0};
 	} Settings;  /// Fog of war settings
 
     uint8_t State { States::cFirstEntry };    /// State of the fog of war calculation process
@@ -101,6 +102,9 @@ private:
     std::vector<uint8_t> RenderedFog;         /// Back buffer for bilinear upscaling in to viewports
     CBlurer              Blurer;              /// Blurer for fog of war texture
 
+    uint8_t              FogColorR       {0};
+    uint8_t              FogColorG       {0};
+    uint8_t              FogColorB       {0};
 
     /// Table with patterns to generate fog of war texture from vision table
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -109,7 +109,7 @@ private:
                                               /// ThisPlayer and his allies in normal games
                                               /// Any set of players for observers and in the replays
     std::vector<uint8_t> VisTable;            /// vision table for whole map + 1 tile around (for simplification of upscale algorithm purposes)
-    intptr_t             VisTable_Index0 {0}; /// index in the vision table for [0:0] tile
+    size_t               VisTable_Index0 {0}; /// index in the vision table for [0:0] tile
     size_t               VisTableWidth   {0}; /// width of the vision table
     CEasedTexture        FogTexture;          /// Upscaled fog texture (alpha-channel values only) for whole map 
                                               /// + 1 tile around (for simplification of upscale algorithm purposes).

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -59,6 +59,9 @@ public:
     CColor   GetFogColor()    const { return Settings.FogColor; }
     uint32_t GetFogColorSDL() const { return Settings.FogColorSDL; }
 
+    void ShowVisionFor(const CPlayer &player) { VisionFor.insert(player.Index); }
+    void HideVisionFor(const CPlayer &player) { VisionFor.erase(player.Index); }
+
     void SetFogColor(uint8_t r, uint8_t g, uint8_t b);
     void SetFogColor(CColor color);
 
@@ -69,7 +72,7 @@ public:
     void GetFogForViewport(const CViewport &viewport, SDL_Surface *const vpSurface);
 
 private:
-    void GenerateFog(const CPlayer &thisPlayer);
+    void GenerateFog();
     void FogUpscale4x4();
 
     uint8_t DeterminePattern(const size_t index, const uint8_t visFlag) const;
@@ -98,6 +101,9 @@ private:
 
     uint8_t State { States::cFirstEntry };    /// State of the fog of war calculation process
     
+    std::set<uint8_t>    VisionFor;           /// Visibilty through the fog is generated for this players
+                                              /// ThisPlayer and his allies in normal games
+                                              /// Any set of players for observers and in the replays
     std::vector<uint8_t> VisTable;            /// vision table for whole map + 1 tile around (for simplification of upscale algorithm purposes)
     intptr_t             VisTable_Index0 {0}; /// index in the vision table for [0:0] tile
     size_t               VisTableWidth   {0}; /// width of the vision table

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -66,6 +66,10 @@ public:
     void SetFogColor(CColor color);
 
     void EnableBilinearUpscale(const bool enable);
+    bool IsBilinearUpscaleEnabled() const 
+    {
+        return Settings.UpscaleType == UpscaleTypes::cBilinear;
+    }
     void InitBlurer(const float radius1, const float radius2, const uint16_t numOfIterations);
 
     void Update(bool doAtOnce = false);

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -153,4 +153,52 @@ private:
 
 extern CFogOfWar FogOfWar;
 
+
+/**
+**  Determine upscale patterns (index in the upscale table) for Visible and Explored layers
+**
+**  @param  index       tile in the vision table 
+**  @param  visFlag     layer to determine pattern for
+**
+*/
+inline uint8_t CFogOfWar::DeterminePattern(const size_t index, const uint8_t visFlag) const
+{
+    Assert(visFlag == VisionType::cVisible || visFlag == (VisionType::cExplored | VisionType::cVisible));
+
+    uint8_t n1, n2, n3, n4;
+    size_t offset = index;
+
+    n1 = (visFlag & VisTable[offset]);
+    n2 = (visFlag & VisTable[offset + 1]);
+    offset += VisTableWidth;
+    n3 = (visFlag & VisTable[offset]);
+    n4 = (visFlag & VisTable[offset + 1]);
+    
+    n1 >>= n1 - VisionType::cExplored;
+    n2 >>= n2 - VisionType::cExplored;
+    n3 >>= n3 - VisionType::cExplored;
+    n4 >>= n4 - VisionType::cExplored;
+    
+    return ( (n1 << 3) | (n2 << 2) | (n3 << 1) | n4 );
+}
+
+/**
+**  Fill 4x4 sized tile in the fog texture according to the patterns
+**
+**  @param  texture         pointer to the texture to fill
+**  @param  textureWidth    width of the texture
+**  @param  index           index of the tile to fill
+**  @param  patternVisible  index int the upscale table for Visible layer
+**  @param  patternExplored index int the upscale table for Explored layer
+**
+*/
+inline void CFogOfWar::FillUpscaledRec(uint32_t *texture, const uint16_t textureWidth, size_t index, 
+                                const uint8_t patternVisible, const uint8_t patternExplored) const
+{
+    for (uint8_t scan_line = 0; scan_line < 4; scan_line++) {
+        texture[index] = UpscaleTable[patternVisible][scan_line] + UpscaleTable[patternExplored][scan_line];
+        index += textureWidth;
+    }
+}
+
 #endif // !__FOW_H__

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -42,6 +42,11 @@
 
 class CViewport;
 
+
+/*----------------------------------------------------------------------------
+--  Declarations
+----------------------------------------------------------------------------*/
+/// Class for box blur algorithm. Used to blur upscaled FOW texture.
 class CBlurer
 {
 public:
@@ -57,25 +62,19 @@ private:
     static float Radius;
     static uint8_t NumOfIterations;
 
-    static std::vector<uint8_t> BoxRadius; /// Radiuses (box sizes) for box blur iterations
+    static std::vector<uint8_t> HalfBoxes; /// Radiuses (box sizes) for box blur iterations
     
     std::vector<uint8_t> WorkingTexture;
     uint16_t TextureWidth {0};
     uint16_t TextureHeight {0};
-    
-    ///int NumOfPasses {3};
-
 };
 
-/*----------------------------------------------------------------------------
---  Declarations
-----------------------------------------------------------------------------*/
 enum class FogOfWarTypes { cLegacy, cEnhanced, NumOfTypes };
 
 class CFogOfWar
 {
 public:
-    enum VisionType { cUnseen  = 0, cExplored = 0b001, cVisible = 0b010, cCached      = 0b100};
+    enum VisionType { cUnseen  = 0, cExplored = 0b001, cVisible = 0b010, cCached = 0b100};
 
     ~CFogOfWar()
     {
@@ -109,7 +108,7 @@ private:
         
 	} Settings;
 
-    /// cached vision table. Tiles filled only once even if it present in the several viewports
+    /// cached vision table. Tiles filled only once per cycle even if they present in the several viewports
     static std::vector<uint8_t> VisTableCache; 
     static intptr_t VisCache_Index0; /// index in the cached vision table for [0:0] tile
     static size_t   VisCacheWidth;   /// width of the cached vision table

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -72,9 +72,9 @@ private:
     void FillUpscaledRec(uint32_t *texture, const int textureWidth, intptr_t index, const uint8_t patternVisible, 
                                                                                     const uint8_t patternExplored);
     void RenderToSurface(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
+                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect, const PixelDiff &offset, const SDL_Rect &renderRect);
     void UpscaleBilinear(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
-                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
+                         SDL_Surface *const trgSurface, const SDL_Rect &trgRect, const PixelDiff &offset, const SDL_Rect &renderRect);
     void UpscaleSimple(const uint8_t *src, const SDL_Rect &srcRect, const int16_t srcWidth,
                        SDL_Surface *const trgSurface, const SDL_Rect &trgRect);
 

--- a/src/include/fow.h
+++ b/src/include/fow.h
@@ -45,7 +45,8 @@ class CViewport;
 class CBlurer
 {
 public:
-    static void Init(const float radius = 1.5, const uint8_t numOfIterations = 2);
+    static void Init();
+    static void Init(const float radius, const uint8_t numOfIterations);
     void Setup(const uint16_t textureWidth, const uint16_t textureHeight);
     void Blur(uint8_t *texture);
 private:
@@ -53,7 +54,7 @@ private:
 
 private:
     static float Radius;
-    static uint8_t NumOfIteratons;
+    static uint8_t NumOfIterations;
 
     static std::vector<uint8_t> BoxRadius; /// Radiuses (box sizes) for box blur iterations
     

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -61,15 +61,15 @@ public:
         isWatingForNext = true;
     }
 
-    void Ease(bool forcedLastStep = false)
+    void Ease()
     {
         if (CurrentStep < EasingStepsNum) CurrentStep++;
     }
-    void PrepareTransition()
+    void PrepareTransition(bool forcedShowNext = false)
     {
         CalcDeltas();
         SwapFrames();
-        CurrentStep = 0;
+        CurrentStep = forcedShowNext ? EasingStepsNum: 0;
         isWatingForNext = true;
     }
 

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -10,7 +10,7 @@
 //
 /**@name fow_utils.h - The utilities for fog of war headerfile. */
 //
-//      (c) Copyright 2020 Alyokhin
+//      (c) Copyright 2021 Alyokhin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by
@@ -38,8 +38,6 @@
 //@{
 
 
-
-
 class CViewport;
 
 
@@ -52,31 +50,12 @@ public:
     void Init(const uint16_t width, const uint16_t height, const uint8_t numOfSteps);
     void Clean();
 
-    bool isFullyEased() { return CurrentStep == EasingStepsNum ? true : false; }
-
-    void SetNumOfSteps (const uint8_t num)
-    {
-        EasingStepsNum  = num;
-        CurrentStep     = EasingStepsNum;
-        isWatingForNext = true;
-    }
-
-    void Ease()
-    {
-        if (CurrentStep < EasingStepsNum) CurrentStep++;
-    }
-    
-    void PrepareTransition(bool forcedShowNext = false)
-    {
-        CalcDeltas();
-        SwapFrames();
-        CurrentStep = forcedShowNext ? EasingStepsNum: 0;
-        isWatingForNext = true;
-    }
-
-    void PushNext() { isWatingForNext = false; }
-    
+    void SetNumOfSteps (const uint8_t num);
+    void PushNext(bool forcedShowNext = false);
     void DrawRegion(uint8_t *target, const uint16_t trgWidth, const uint16_t x0, const uint16_t y0, const SDL_Rect &srcRect);
+
+    bool isFullyEased() { return CurrentStep == EasingStepsNum ? true : false; }
+    void Ease()         { if (CurrentStep < EasingStepsNum) CurrentStep++; }
 
     uint8_t *GetCurrent() { return Frames[Prev].data(); }
     uint8_t *GetNext()    { return Frames[Next].data(); }
@@ -98,7 +77,6 @@ private:
     uint8_t              Prev  {0};
     uint8_t              Curr  {1};
     uint8_t              Next  {2};
-    bool                 isWatingForNext {false};
 
     std::vector<int16_t> Deltas;
 };
@@ -111,7 +89,7 @@ public:
     void PrecalcParameters(const float radius, const int numOfIterations);
     
     void Clean();
-    void Blur(uint8_t *texture);
+    void Blur(uint8_t *const texture);
 private:
     void ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t radius);
 

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -10,7 +10,7 @@
 //
 /**@name fow_utils.h - The utilities for fog of war headerfile. */
 //
-//      (c) Copyright 2021 Alyokhin
+//      (c) Copyright 2020-2021 by Alyokhin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by
@@ -81,7 +81,7 @@ private:
     std::vector<int16_t> Deltas;
 };
 
-/// Class for box blur algorithm. Used to blur upscaled FOW texture.
+/// Class for box blur algorithm. Used to blur 4x4 upscaled FOW texture.
 class CBlurer
 {
 public:
@@ -99,7 +99,7 @@ private:
     uint8_t NumOfIterations {3}; /// 2-3 is optimal, with higher values result enhancing not so radicaly
 
     std::vector<uint8_t> HalfBoxes; /// Radiuses (box sizes) for box blur iterations
-    std::vector<uint8_t> WorkingTexture;
+    std::vector<uint8_t> WorkingTexture;  /// Back buffer
     uint16_t TextureWidth  {0};
     uint16_t TextureHeight {0};
 };

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -1,0 +1,130 @@
+//       _________ __                 __
+//      /   _____//  |_____________ _/  |______     ____  __ __  ______
+//      \_____  \\   __\_  __ \__  \\   __\__  \   / ___\|  |  \/  ___/
+//      /        \|  |  |  | \// __ \|  |  / __ \_/ /_/  >  |  /\___ |
+//     /_______  /|__|  |__|  (____  /__| (____  /\___  /|____//____  >
+//             \/                  \/          \//_____/            \/
+//  ______________________                           ______________________
+//                        T H E   W A R   B E G I N S
+//         Stratagus - A free fantasy real time strategy game engine
+//
+/**@name fow_utils.h - The utilities for fog of war headerfile. */
+//
+//      (c) Copyright 2020 Alyokhin
+//
+//      This program is free software; you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation; only version 2 of the License.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program; if not, write to the Free Software
+//      Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+//      02111-1307, USA.
+//
+
+#ifndef __FOW_UTILS_H__
+#define __FOW_UTILS_H__
+
+#include <cstdint>
+#include <vector>
+#include "SDL.h"
+
+
+//@{
+
+
+
+
+class CViewport;
+
+
+/*----------------------------------------------------------------------------
+--  Declarations
+----------------------------------------------------------------------------*/
+class CEasedTexture
+{
+public:
+    void Init(const uint16_t width, const uint16_t height, const uint8_t numOfSteps);
+    void Clean();
+
+    bool isFullyEased() { return CurrentStep == EasingStepsNum ? true : false; }
+
+    void SetNumOfSteps (const uint8_t num)
+    {
+        EasingStepsNum  = num;
+        CurrentStep     = EasingStepsNum;
+        isWatingForNext = true;
+    }
+
+    void Ease(bool forcedLastStep = false)
+    {
+        if (CurrentStep < EasingStepsNum) CurrentStep++;
+    }
+    void PrepareTransition()
+    {
+        CalcDeltas();
+        SwapFrames();
+        CurrentStep = 0;
+        isWatingForNext = true;
+    }
+
+    void PushNext() { isWatingForNext = false; }
+    
+    void DrawRegion(uint8_t *target, const uint16_t trgWidth, const uint16_t x0, const uint16_t y0, const SDL_Rect &srcRect);
+
+    uint8_t *GetCurrent() { return Frames[Prev].data(); }
+    uint8_t *GetNext()    { return Frames[Next].data(); }
+    uint16_t GetWidth()   { return Width;               }
+    uint16_t GetHeight()  { return Height;              }
+
+private:
+    void CalcDeltas();
+    void SwapFrames() { const uint8_t swap = Prev; Prev = Curr; Curr = Next; Next = swap; }
+
+private:
+    uint8_t  CurrentStep    {0};
+    uint8_t  EasingStepsNum {0}; 
+    uint16_t Width          {0};
+    uint16_t Height         {0};
+    size_t   TextureSize    {0}; // Width * Height
+
+    std::vector<uint8_t> Frames[3];
+    uint8_t              Prev  {0};
+    uint8_t              Curr  {1};
+    uint8_t              Next  {2};
+    bool                 isWatingForNext {false};
+
+    std::vector<int16_t> Deltas;
+};
+
+/// Class for box blur algorithm. Used to blur upscaled FOW texture.
+class CBlurer
+{
+public:
+    void Init(const uint16_t textureWidth, const uint16_t textureHeight, const float radius, const int numOfIterations);
+    void PrecalcParameters(const float radius, const int numOfIterations);
+    
+    void Clean();
+    void Blur(uint8_t *texture);
+private:
+    void ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t radius);
+
+private:
+    float   Radius          {2}; /// From 1 to 3 is optimal. With 3 result is very smooth, 
+                                 /// but it opens about 1/2 extra tiles around SightRange circle
+    uint8_t NumOfIterations {3}; /// 2-3 is optimal, with higher values result enhancing not so radicaly
+
+    std::vector<uint8_t> HalfBoxes; /// Radiuses (box sizes) for box blur iterations
+    std::vector<uint8_t> WorkingTexture;
+    uint16_t TextureWidth  {0};
+    uint16_t TextureHeight {0};
+};
+
+
+
+#endif // !__FOW_UTILS_H__

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -54,13 +54,13 @@ public:
     void PushNext(const bool forcedShowNext = false);
     void DrawRegion(uint8_t *target, const uint16_t trgWidth, const uint16_t x0, const uint16_t y0, const SDL_Rect &srcRect);
 
-    bool isFullyEased() { return CurrentStep == EasingStepsNum ? true : false; }
-    void Ease()         { if (CurrentStep < EasingStepsNum) CurrentStep++; }
+    bool isFullyEased() const { return CurrentStep == EasingStepsNum ? true : false; }
+    void Ease()               { if (CurrentStep < EasingStepsNum) CurrentStep++; }
 
-    uint8_t *GetCurrent() { return Frames[Prev].data(); }
-    uint8_t *GetNext()    { return Frames[Next].data(); }
-    uint16_t GetWidth()   { return Width;               }
-    uint16_t GetHeight()  { return Height;              }
+    uint8_t *GetCurrent()      { return Frames[Prev].data(); }
+    uint8_t *GetNext()         { return Frames[Next].data(); }
+    uint16_t GetWidth()  const { return Width;  }
+    uint16_t GetHeight() const { return Height; }
 
 private:
     void CalcDeltas();

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -65,6 +65,7 @@ public:
     {
         if (CurrentStep < EasingStepsNum) CurrentStep++;
     }
+    
     void PrepareTransition(bool forcedShowNext = false)
     {
         CalcDeltas();

--- a/src/include/fow_utils.h
+++ b/src/include/fow_utils.h
@@ -50,8 +50,8 @@ public:
     void Init(const uint16_t width, const uint16_t height, const uint8_t numOfSteps);
     void Clean();
 
-    void SetNumOfSteps (const uint8_t num);
-    void PushNext(bool forcedShowNext = false);
+    void SetNumOfSteps(const uint8_t num);
+    void PushNext(const bool forcedShowNext = false);
     void DrawRegion(uint8_t *target, const uint16_t trgWidth, const uint16_t x0, const uint16_t y0, const SDL_Rect &srcRect);
 
     bool isFullyEased() { return CurrentStep == EasingStepsNum ? true : false; }

--- a/src/include/interface.h
+++ b/src/include/interface.h
@@ -10,7 +10,7 @@
 //
 /**@name interface.h - The user interface header file. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/interface.h
+++ b/src/include/interface.h
@@ -10,7 +10,7 @@
 //
 /**@name interface.h - The user interface header file. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/interface.h
+++ b/src/include/interface.h
@@ -425,6 +425,8 @@ extern bool ButtonCheckUpgradeTo(const CUnit &unit, const ButtonAction &button);
 extern bool ButtonCheckResearch(const CUnit &unit, const ButtonAction &button);
 /// Check if all requirements for a single research are meet
 extern bool ButtonCheckSingleResearch(const CUnit &unit, const ButtonAction &button);
+/// Check for button enabled, if requested condition passes check. Used for debug purposes
+extern bool ButtonCheckDebug(const CUnit &unit, const ButtonAction &button);
 
 //
 // in ccl_ui.c

--- a/src/include/map.h
+++ b/src/include/map.h
@@ -391,7 +391,10 @@ void MapMarkUnitSight(CUnit &unit);
 /// Unmark on vision table the Sight of the unit.
 void MapUnmarkUnitSight(CUnit &unit);
 ///Mark/Unmark on vision table the Sight for the units around the tilePos
-void MapRefreshUnitsSightAroundTile(const Vec2i &tilePos, const bool resetSight = false);
+void MapRefreshUnitsSight(const Vec2i &tilePos, const bool resetSight = false);
+///Mark/Unmark on vision table the Sight for all units on the map
+void MapRefreshUnitsSight(const bool resetSight = false);
+
 /*----------------------------------------------------------------------------
 --  Defines
 ----------------------------------------------------------------------------*/

--- a/src/include/map.h
+++ b/src/include/map.h
@@ -10,7 +10,7 @@
 //
 /**@name map.h - The map headerfile. */
 //
-//      (c) Copyright 1998-2021 by Vladi Shabanski, Lutz Sammer, and
+//      (c) Copyright 1998-2006 by Vladi Shabanski, Lutz Sammer, and
 //                                 Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/include/map.h
+++ b/src/include/map.h
@@ -187,9 +187,9 @@ public:
 	/// Build tables for fog of war
 	void InitLegacyFogOfWar();
 	/// Clean the map
-	void Clean();
+	void Clean(const bool isHardClean = false);
 	/// Cleanup memory for fog of war tables
-	void CleanLegacyFogOfWar();
+	void CleanLegacyFogOfWar(const bool isHardClean = false);
 
 	/// Remove wood, rock or wall from the map and update nearby unit's vision if needed
 	void ClearTile(const Vec2i &tilePos);

--- a/src/include/map.h
+++ b/src/include/map.h
@@ -175,14 +175,21 @@ public:
 		return Field(pos.x, pos.y);
 	}
 
+	bool isInitialized() const
+	{
+		return this->isMapInitialized;
+	}
+
 	/// Alocate and initialise map table.
 	void Create();
 	/// Build tables for map
 	void Init();
+	/// Build tables for fog of war
+	void InitLegacyFogOfWar();
 	/// Clean the map
 	void Clean();
 	/// Cleanup memory for fog of war tables
-	void CleanFogOfWar();
+	void CleanLegacyFogOfWar();
 
 	/// Remove wood, rock or wall from the map and update nearby unit's vision if needed
 	void ClearTile(const Vec2i &tilePos);
@@ -242,9 +249,6 @@ public:
 	}
 
 private:
-	/// Build tables for fog of war
-	void InitFogOfWar();
-
 	/// Remove wood from the map.
 	void ClearWoodTile(const Vec2i &pos);
 	/// Remove rock from the map.
@@ -259,15 +263,16 @@ private:
 	void RegenerateForestTile(const Vec2i &pos);
 
 public:
-	CMapField *Fields;              /// fields on map
-	bool NoFogOfWar;           /// fog of war disabled
+	CMapField *Fields;              	/// fields on map
+	bool NoFogOfWar;           			/// fog of war disabled
 
-	CTileset *Tileset;          /// tileset data
-	std::string TileModelsFileName; /// lua filename that loads all tilemodels
-	CGraphic *TileGraphic;     /// graphic for all the tiles
-	static CGraphic *FogGraphic;      /// graphic for fog of war
+	CTileset *Tileset;          		/// tileset data
+	std::string TileModelsFileName; 	/// lua filename that loads all tilemodels
+	CGraphic *TileGraphic;     			/// graphic for all the tiles
+	static CGraphic *LegacyFogGraphic;  /// graphic for legacy fog of war
+	bool isMapInitialized { false };
 
-	CMapInfo Info;             /// descriptive information
+	CMapInfo Info;             			/// descriptive information
 };
 
 

--- a/src/include/map.h
+++ b/src/include/map.h
@@ -10,7 +10,7 @@
 //
 /**@name map.h - The map headerfile. */
 //
-//      (c) Copyright 1998-2006 by Vladi Shabanski, Lutz Sammer, and
+//      (c) Copyright 1998-2021 by Vladi Shabanski, Lutz Sammer, and
 //                                 Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/include/net_message.h
+++ b/src/include/net_message.h
@@ -321,8 +321,11 @@ enum _message_type_ {
 **  Network extended message types.
 */
 enum _extended_message_type_ {
-	ExtendedMessageDiplomacy,     /// Change diplomacy
-	ExtendedMessageSharedVision   /// Change shared vision
+	ExtendedMessageDiplomacy,         /// Change diplomacy
+	ExtendedMessageSharedVision,      /// Change shared vision
+	ExtendedMessageAutoTargetingDB,   /// Change Auto targetting algorithm. Used for debug purposes
+	ExtendedMessageFieldOfViewDB,     /// Change field of view type (shadow casting or radial). Used for debug purposes
+	ExtendedMessageMapFieldsOpacityDB /// Change opaque flag for forest, rocks or walls. Used for debug purposes
 };
 
 /**

--- a/src/include/net_message.h
+++ b/src/include/net_message.h
@@ -10,7 +10,7 @@
 //
 /**@name net_message.h - The network message header file. */
 //
-//      (c) Copyright 2013 by Joris Dauphin
+//      (c) Copyright 2021 by Joris Dauphin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/net_message.h
+++ b/src/include/net_message.h
@@ -10,7 +10,7 @@
 //
 /**@name net_message.h - The network message header file. */
 //
-//      (c) Copyright 2021 by Joris Dauphin
+//      (c) Copyright 2013 by Joris Dauphin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -10,7 +10,7 @@
 //
 /**@name player.h - The player headerfile. */
 //
-//      (c) Copyright 1998-2005 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -10,7 +10,7 @@
 //
 /**@name player.h - The player headerfile. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2005 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -254,6 +254,10 @@ public:
 	{
 		return this->HasVisionFrom;
 	}
+	const std::set<uint8_t> &GetGaveVisionTo() const
+	{
+		return this->GaveVisionTo;
+	}
 	bool HasSharedVisionWith(const CPlayer &player) const
 	{
 		return (this->GaveVisionTo.find(player.Index) != this->GaveVisionTo.end());

--- a/src/include/player.h
+++ b/src/include/player.h
@@ -250,18 +250,14 @@ public:
 	bool IsAllied(const CPlayer &player) const;
 	bool IsAllied(const CUnit &unit) const;
 	bool IsVisionSharing() const;
-	const std::set<int> &GetSharedVision() const
+	const std::set<uint8_t> &GetSharedVision() const
 	{
-		return this->SharedVision;
+		return this->HasVisionFrom;
 	}
-	bool HasSharedVisionWith(const int playerIndex) const
+	bool HasSharedVisionWith(const CPlayer &player) const
 	{
-		return (this->SharedVision.find(playerIndex) != this->SharedVision.end());
+		return (this->GaveVisionTo.find(player.Index) != this->GaveVisionTo.end());
 	}
-	bool HasSharedVisionWith(const CPlayer &player) const;
-	bool HasSharedVisionWith(const CUnit &unit) const;
-	bool HasMutualSharedVisionWith(const CPlayer &player) const;
-	bool HasMutualSharedVisionWith(const CUnit &unit) const;
 	bool IsTeamed(const CPlayer &player) const;
 	bool IsTeamed(const CUnit &unit) const;
 
@@ -270,8 +266,10 @@ public:
 	void SetDiplomacyEnemyWith(const CPlayer &player);
 	void SetDiplomacyCrazyWith(const CPlayer &player);
 
-	void ShareVisionWith(const CPlayer &player);
-	void UnshareVisionWith(const CPlayer &player);
+	void ShareVisionWith(CPlayer &player);
+	void EnableSharedVisionFrom(const CPlayer &player);
+	void UnshareVisionWith(CPlayer &player);
+	void DisableSharedVisionFrom(const CPlayer &player);
 
 	void Init(/* PlayerTypes */ int type);
 	void Save(CFile &file) const;
@@ -284,10 +282,12 @@ public:
 	void SetRevealed(const bool revealed);
 
 private:
-	std::vector<CUnit *> Units; /// units of this player
-	unsigned int Enemy;         /// enemy bit field for this player
-	unsigned int Allied;        /// allied bit field for this player
-	std::set<int> SharedVision; /// set of player indexes that this player has shared vision with
+	std::vector<CUnit *> Units;        /// units of this player
+	unsigned int Enemy;                /// enemy bit field for this player
+	unsigned int Allied;               /// allied bit field for this player
+	std::set<uint8_t> HasVisionFrom;   /// set of player indexes that have shared their vision with this player
+	std::set<uint8_t> GaveVisionTo;    /// set of player indexes that this player has shared vision with
+
 	bool isRevealed { false }; 	/// whether the player has been revealed (i.e. after losing the last Town Hall)
 
 	friend void CleanPlayers();

--- a/src/include/script.h
+++ b/src/include/script.h
@@ -301,6 +301,7 @@ extern int CclInConfigFile;        /// True while config file parsing
 
 extern const char *LuaToString(lua_State *l, int narg);
 extern int LuaToNumber(lua_State *l, int narg);
+extern float LuaToFloat(lua_State *l, int narg);
 extern unsigned int LuaToUnsignedNumber(lua_State *l, int narg);
 extern bool LuaToBoolean(lua_State *l, int narg);
 

--- a/src/include/script.h
+++ b/src/include/script.h
@@ -10,7 +10,7 @@
 //
 /**@name script.h - The clone configuration language headerfile. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2006 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/script.h
+++ b/src/include/script.h
@@ -10,7 +10,7 @@
 //
 /**@name script.h - The clone configuration language headerfile. */
 //
-//      (c) Copyright 1998-2006 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/stratagus.h
+++ b/src/include/stratagus.h
@@ -10,7 +10,7 @@
 //
 /**@name stratagus.h - The main header file. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2007 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/stratagus.h
+++ b/src/include/stratagus.h
@@ -10,7 +10,7 @@
 //
 /**@name stratagus.h - The main header file. */
 //
-//      (c) Copyright 1998-2007 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/stratagus.h
+++ b/src/include/stratagus.h
@@ -113,6 +113,7 @@ extern bool EnableDebugPrint;
 extern bool EnableAssert;
 extern bool EnableUnitDebug;
 extern bool IsDebugEnabled;
+extern bool EnableWallsInSinglePlayer;
 
 extern void AbortAt(const char *file, int line, const char *funcName, const char *conditionStr);
 extern void PrintOnStdOut(const char *format, ...);

--- a/src/include/tileset.h
+++ b/src/include/tileset.h
@@ -10,7 +10,7 @@
 //
 /**@name tileset.h - The tileset headerfile. */
 //
-//      (c) Copyright 1998-2005 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/tileset.h
+++ b/src/include/tileset.h
@@ -10,7 +10,7 @@
 //
 /**@name tileset.h - The tileset headerfile. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2005 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/title.h
+++ b/src/include/title.h
@@ -10,7 +10,7 @@
 //
 /**@name title.h - The title screen headerfile. */
 //
-//      (c) Copyright 2007 by Jimmy Salmon
+//      (c) Copyright 2021 by Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/title.h
+++ b/src/include/title.h
@@ -10,7 +10,7 @@
 //
 /**@name title.h - The title screen headerfile. */
 //
-//      (c) Copyright 2021 by Jimmy Salmon
+//      (c) Copyright 2007 by Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -10,7 +10,7 @@
 //
 /**@name ui.h - The user interface header file. */
 //
-//      (c) Copyright 1999-2007 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1999-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -10,7 +10,7 @@
 //
 /**@name ui.h - The user interface header file. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1999-2007 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/unit.h
+++ b/src/include/unit.h
@@ -193,7 +193,7 @@ public:
 	inline bool IsInvisibile(const CPlayer &player) const
 	{
 		return (&player != Player && Variable[INVISIBLE_INDEX].Value > 0
-				&& !player.HasMutualSharedVisionWith(*Player));
+				&& !Player->HasSharedVisionWith(player));
 	}
 
 	/**
@@ -268,10 +268,6 @@ public:
 	bool IsEnemy(const CUnit &unit) const;
 	bool IsAllied(const CPlayer &player) const;
 	bool IsAllied(const CUnit &unit) const;
-	bool HasSharedVisionWith(const CPlayer &player) const;
-	bool HasSharedVisionWith(const CUnit &unit) const;
-	bool HasMutualSharedVisionWith(const CPlayer &player) const;
-	bool HasMutualSharedVisionWith(const CUnit &unit) const;
 	bool IsTeamed(const CPlayer &player) const;
 	bool IsTeamed(const CUnit &unit) const;
 

--- a/src/include/unit_manager.h
+++ b/src/include/unit_manager.h
@@ -10,7 +10,7 @@
 //
 /**@name unit_manager.h - Unit manager header. */
 //
-//      (c) Copyright 2021 by Jimmy Salmon
+//      (c) Copyright 2007 by Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/unit_manager.h
+++ b/src/include/unit_manager.h
@@ -64,6 +64,11 @@ public:
 	void Add(CUnit *unit);
 	Iterator begin();
 	Iterator end();
+	const std::vector<CUnit *> &GetUnits() const
+	{
+		return units;
+	}
+
 	bool empty() const;
 
 	CUnit *lastCreatedUnit();

--- a/src/include/unit_manager.h
+++ b/src/include/unit_manager.h
@@ -10,7 +10,7 @@
 //
 /**@name unit_manager.h - Unit manager header. */
 //
-//      (c) Copyright 2007 by Jimmy Salmon
+//      (c) Copyright 2021 by Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -10,7 +10,7 @@
 //
 /**@name unittype.h - The unit-types headerfile. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -10,7 +10,7 @@
 //
 /**@name unittype.h - The unit-types headerfile. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/video.h
+++ b/src/include/video.h
@@ -215,22 +215,22 @@ struct EventCallback {
 };
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-#define RSHIFT  0
+#define RSHIFT  16
 #define GSHIFT  8
-#define BSHIFT  16
+#define BSHIFT  0
 #define ASHIFT  24
-#define RMASK   0x000000ff
+#define RMASK   0x00ff0000
 #define GMASK   0x0000ff00
-#define BMASK   0x00ff0000
+#define BMASK   0x000000ff
 #define AMASK   0xff000000
 #else
-#define RSHIFT  24
+#define RSHIFT  8
 #define GSHIFT  16
-#define BSHIFT  8
+#define BSHIFT  24
 #define ASHIFT  0
-#define RMASK   0xff000000
+#define RMASK   0x0000ff00
 #define GMASK   0x00ff0000
-#define BMASK   0x0000ff00
+#define BMASK   0xff000000
 #define AMASK   0x000000ff
 #endif
 

--- a/src/include/video.h
+++ b/src/include/video.h
@@ -10,7 +10,7 @@
 //
 /**@name video.h - The video headerfile. */
 //
-//      (c) Copyright 1999-2011 by Lutz Sammer, Nehal Mistry, Jimmy Salmon and
+//      (c) Copyright 1999-2021 by Lutz Sammer, Nehal Mistry, Jimmy Salmon and
 //                                 Pali Rohár
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/include/video.h
+++ b/src/include/video.h
@@ -10,7 +10,7 @@
 //
 /**@name video.h - The video headerfile. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Nehal Mistry, Jimmy Salmon and
+//      (c) Copyright 1999-2011 by Lutz Sammer, Nehal Mistry, Jimmy Salmon and
 //                                 Pali Rohár
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -10,7 +10,7 @@
 //
 /**@name viewport.h - The Viewport header file. */
 //
-//      (c) Copyright 2012 by Joris Dauphin
+//      (c) Copyright 2021 by Joris Dauphin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -116,6 +116,8 @@ private:
 	void DrawEnhancedFogOfWar(const bool isSoftwareRender = true);
 	/// Adjust fog of war surface to viewport
 	void AdjustFogSurface();
+	/// Clean enhanced fog of war texture
+	void CleanEnhFog();
 
 public:
 	//private:
@@ -130,7 +132,7 @@ public:
 
 	CUnit *Unit;              /// Bound to this unit
 private:
-	SDL_Surface *FogSurface {nullptr}; /// Fog of war texture. Viewport sized.
+	SDL_Surface *EnhFogSurface { nullptr }; /// Texture for enhanced fog of war. Viewport sized.
 
 };
 

--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -99,6 +99,16 @@ public:
 	void Restrict(int &screenPosX, int &screenPosY) const;
 	void Clean();
 
+	static bool isGridEnabled()
+	{
+		return CViewport::ShowGrid;
+	}
+
+	static void EnableGrid(const bool value)
+	{
+		CViewport::ShowGrid = value;
+	}
+
 
 	PixelSize GetPixelSize() const;
 	const PixelPos &GetTopLeftPos() const { return TopLeftPos;}
@@ -133,8 +143,10 @@ public:
 	CUnit *Unit;              /// Bound to this unit
 private:
 	SDL_Surface *EnhFogSurface { nullptr }; /// Texture for enhanced fog of war. Viewport sized.
+	static bool ShowGrid;
 
 };
+
 
 //@}
 

--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -113,7 +113,7 @@ private:
 	/// Draw the map fog of war
 	void DrawMapFogOfWar();
 	void DrawLegacyFogOfWar() const;
-	void DrawEnhancedFogOfWar();
+	void DrawEnhancedFogOfWar(const bool isSoftwareRender = true);
 	/// Adjust fog of war surface to viewport
 	void AdjustFogSurface();
 
@@ -130,7 +130,7 @@ public:
 
 	CUnit *Unit;              /// Bound to this unit
 private:
-	SDL_Surface *FogSurface {nullptr};
+	SDL_Surface *FogSurface {nullptr}; /// Fog of war texture. Viewport sized.
 
 };
 

--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -97,6 +97,8 @@ public:
 	bool Contains(const PixelPos &screenPos) const;
 
 	void Restrict(int &screenPosX, int &screenPosY) const;
+	void Clean();
+
 
 	PixelSize GetPixelSize() const;
 	const PixelPos &GetTopLeftPos() const { return TopLeftPos;}
@@ -109,7 +111,11 @@ private:
 	/// Draw the map background
 	void DrawMapBackgroundInViewport() const;
 	/// Draw the map fog of war
-	void DrawMapFogOfWar() const;
+	void DrawMapFogOfWar();
+	void DrawLegacyFogOfWar() const;
+	void DrawEnhancedFogOfWar();
+	/// Adjust fog of war surface to viewport
+	void AdjustFogSurface();
 
 public:
 	//private:
@@ -124,7 +130,7 @@ public:
 
 	CUnit *Unit;              /// Bound to this unit
 private:
-	CFogOfWar FogOfWar;
+	SDL_Surface *FogSurface {nullptr};
 
 };
 

--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -10,7 +10,7 @@
 //
 /**@name viewport.h - The Viewport header file. */
 //
-//      (c) Copyright 2021 by Joris Dauphin
+//      (c) Copyright 2012 by Joris Dauphin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/fov.cpp
+++ b/src/map/fov.cpp
@@ -444,11 +444,11 @@ void CFieldOfView::PrepareCache(const Vec2i pos, const uint16_t width, const uin
 	bottomRight.y =  pos.y + height + range;
 	Map.Clamp(bottomRight);
 
-	const uint16_t sightRecWidth = bottomRight.x - upperLeft.x;
+	const uint16_t sightRecWidth = bottomRight.x - upperLeft.x + 1;
 
 	size_t index = upperLeft.x + upperLeft.y * Map.Info.MapWidth;
 
-	for (uint16_t y = upperLeft.y; y < bottomRight.y; y++ ) {
+	for (uint16_t y = upperLeft.y; y <= bottomRight.y; y++ ) {
 		std::fill_n(&MarkedTilesCache[index], sightRecWidth, 0);
 		index += Map.Info.MapWidth;
 	}

--- a/src/map/fov.cpp
+++ b/src/map/fov.cpp
@@ -212,7 +212,7 @@ void CFieldOfView::ProceedSimpleRadial(const CPlayer &player, const Vec2i &pos,
 **  @param height			Spectrator's height in tiles
 **  @param range			Spectrator's sight range in tiles
 */
-void CFieldOfView::ProceedShadowCasting(const Vec2i &spectatorPos, const uint16_t width, const uint16_t height, const uint16_t range)
+inline void CFieldOfView::ProceedShadowCasting(const Vec2i &spectatorPos, const uint16_t width, const uint16_t height, const uint16_t range)
 {
 	enum SpectatorGeometry {cOneTiled, cEven, cOdd, cTall, cWide} ;
 	const uint8_t geometry = [width, height]{   if (width == height) {

--- a/src/map/fov.cpp
+++ b/src/map/fov.cpp
@@ -35,6 +35,7 @@
 #include "fov.h"
 #include "settings.h"
 #include "unit.h"
+#include "unit_manager.h"
 #include "unittype.h"
 #include "util.h"
 
@@ -54,10 +55,14 @@
 */
 bool CFieldOfView::SetType(const FieldOfViewTypes fov_type)
 {
-	if (fov_type < FieldOfViewTypes::NumOfTypes) {
-		this->Settings.FoV_Type = fov_type;
+	if (fov_type != Settings.Type && fov_type < FieldOfViewTypes::NumOfTypes) {
+		/// Unmark sight for all units
+		MapRefreshUnitsSight(true);
 
+		this->Settings.Type = fov_type;
 		
+		/// Mark sight with new fov type for all units 
+		MapRefreshUnitsSight();
 		return true;
 	} else {
 		return false;
@@ -71,7 +76,7 @@ bool CFieldOfView::SetType(const FieldOfViewTypes fov_type)
 */
 FieldOfViewTypes CFieldOfView::GetType() const
 {
-	return this->Settings.FoV_Type;
+	return this->Settings.Type;
 }
 
 /** 
@@ -81,7 +86,15 @@ FieldOfViewTypes CFieldOfView::GetType() const
 */
 void CFieldOfView::SetOpaqueFields(const uint16_t flags)
 {
-	this->Settings.OpaqueFields = flags;
+	if (this->Settings.OpaqueFields != flags) {
+		/// Unmark sight for all units
+		MapRefreshUnitsSight(true);
+
+		this->Settings.OpaqueFields = flags;
+
+		/// Mark sight with new fov type for all units 
+		MapRefreshUnitsSight();
+	}
 }
 
 /** 
@@ -124,7 +137,7 @@ void CFieldOfView::Refresh(const CPlayer &player, const CUnit &unit, const Vec2i
 	if (!range) {
 		return;
 	}
-	if (this->Settings.FoV_Type == FieldOfViewTypes::cShadowCasting && !unit.Type->AirUnit) {
+	if (this->Settings.Type == FieldOfViewTypes::cShadowCasting && !unit.Type->AirUnit) {
 
 		OpaqueFields = unit.Type->BoolFlag[ELEVATED_INDEX].value ? 0 : this->Settings.OpaqueFields;
 		if (GameSettings.Inside) {

--- a/src/map/fov.cpp
+++ b/src/map/fov.cpp
@@ -56,6 +56,8 @@ bool CFieldOfView::SetType(const FieldOfViewTypes fov_type)
 {
 	if (fov_type < FieldOfViewTypes::NumOfTypes) {
 		this->Settings.FoV_Type = fov_type;
+
+		
 		return true;
 	} else {
 		return false;
@@ -115,6 +117,8 @@ void CFieldOfView::ResetAdditionalOpaqueFields()
 void CFieldOfView::Refresh(const CPlayer &player, const CUnit &unit, const Vec2i &pos, const short width, 
 							const short height, const short range, MapMarkerFunc *marker)
 {
+	/// FIXME: sometimes when quit from game this assert is triggered
+	Assert(unit.Type != NULL);
 	// Units under construction have no sight range.
 	if (!range) {
 		return;

--- a/src/map/fov.cpp
+++ b/src/map/fov.cpp
@@ -118,6 +118,7 @@ void CFieldOfView::Refresh(const CPlayer &player, const CUnit &unit, const Vec2i
 							const short height, const short range, MapMarkerFunc *marker)
 {
 	/// FIXME: sometimes when quit from game this assert is triggered
+	if (!unit.Type) return;
 	Assert(unit.Type != NULL);
 	// Units under construction have no sight range.
 	if (!range) {

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -159,17 +159,18 @@ void CFogOfWar::InitBlurer(const float radius1, const float radius2, const uint1
 */
 void CFogOfWar::GenerateFog(const CPlayer &thisPlayer)
 {
-    size_t visIndex = VisTable_Index0;
-    size_t mapIndex = 0;
-    for (uint16_t row = 0 ; row < Map.Info.MapHeight; row++) {
-		for (uint16_t col = 0; col < Map.Info.MapWidth; col++) {
+    #pragma omp parallel for 
+    for (uint16_t row = 0; row < Map.Info.MapHeight; row++) {
+
+        const size_t visIndex = VisTable_Index0 + row * VisTableWidth;
+        const size_t mapIndex = row * Map.Info.MapHeight;
+
+        for (uint16_t col = 0; col < Map.Info.MapWidth; col++) {
             /// FIXME: to speedup this part, maybe we have to use Map.Field(mapIndex + col)->playerInfo.Visible[thisPlayer.index] instead
             /// this must be much faster
             VisTable[visIndex + col] = Map.Field(mapIndex + col)->playerInfo.TeamVisibilityState(thisPlayer);
-		}
-		visIndex += VisTableWidth;
-        mapIndex += Map.Info.MapWidth;
-	}
+        }
+    }
 }
 
 /**

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -332,7 +332,7 @@ void CFogOfWar::FogUpscale4x4()
 **  @param  visFlag     layer to determine pattern for
 **
 */
-uint8_t CFogOfWar::DeterminePattern(const size_t index, const uint8_t visFlag) const
+inline uint8_t CFogOfWar::DeterminePattern(const size_t index, const uint8_t visFlag) const
 {
     Assert(visFlag == VisionType::cVisible || visFlag == (VisionType::cExplored | VisionType::cVisible));
 
@@ -364,7 +364,7 @@ uint8_t CFogOfWar::DeterminePattern(const size_t index, const uint8_t visFlag) c
 **  @param  patternExplored index int the upscale table for Explored layer
 **
 */
-void CFogOfWar::FillUpscaledRec(uint32_t *texture, const uint16_t textureWidth, size_t index, 
+inline void CFogOfWar::FillUpscaledRec(uint32_t *texture, const uint16_t textureWidth, size_t index, 
                                 const uint8_t patternVisible, const uint8_t patternExplored) const
 {
     for (uint8_t scan_line = 0; scan_line < 4; scan_line++) {

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -142,10 +142,12 @@ void CFogOfWar::GenerateFog(const CPlayer &thisPlayer)
 **  @param viewport     viewport to refresh fog of war for
 **  @param thisPlayer   player to refresh fog of war for
 */
-void CFogOfWar::Update(bool doAtOnce)
+void CFogOfWar::Update(bool doAtOnce /*= false*/)
 {
     
     FogTexture.Ease();
+
+    if (Settings.NumOfEasingSteps < States::cReady) doAtOnce = true;
 
     if (doAtOnce || this->State == cFirstEntry) {
         /// TODO: Add posibility to generate fog for different players (for replays purposes)
@@ -153,10 +155,9 @@ void CFogOfWar::Update(bool doAtOnce)
         UpscaleFog();
         Blurer.Blur(FogTexture.GetNext());
         FogTexture.PushNext();
-        FogTexture.PrepareTransition();
+        FogTexture.PrepareTransition(doAtOnce);
         this->State = cGenerateFog;
     } else {
-
         switch (this->State) {
             case cGenerateFog:
                 /// TODO: Add posibility to generate fog for different players (for replays purposes)

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -61,18 +61,19 @@ CFogOfWar FogOfWar; /// Fog of war itself
 void CFogOfWar::Init()
 {
     /// +1 to the top & left and +1 to the bottom & right for 4x scale algorithm purposes, 
-    /// Extra tiles will always be VisionType::cNone. 
-    VisTableWidth   = Map.Info.MapWidth + 2;    
-    VisTable_Index0 = VisTableWidth + 1;
-
-    const size_t tableSize = VisTableWidth * (Map.Info.MapHeight + 2);
+    /// Extra tiles will always be VisionType::cUnseen. 
+                   VisTableWidth  = Map.Info.MapWidth  + 2;
+    const uint16_t visTableHeight = Map.Info.MapHeight + 2;
+    const size_t   tableSize      = VisTableWidth * visTableHeight;
     VisTable.clear();
     VisTable.resize(tableSize);
     std::fill(VisTable.begin(), VisTable.end(), VisionType::cUnseen);
+    
+    VisTable_Index0 = VisTableWidth + 1;
 
-    /// +1 to the top & left and +1 to the bottom & right for 4x scale algorithm purposes, 
-    const uint16_t fogTextureWidth  = (Map.Info.MapWidth  + 2) * 4;
-    const uint16_t fogTextureHeight = (Map.Info.MapHeight + 2) * 4;
+    /// +1 to the top & left for 4x scale algorithm purposes, 
+    const uint16_t fogTextureWidth  = (Map.Info.MapWidth  + 1) * 4;
+    const uint16_t fogTextureHeight = (Map.Info.MapHeight + 1) * 4;
 
     FogTexture.Init(fogTextureWidth, fogTextureHeight, Settings.NumOfEasingSteps);
     

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -166,10 +166,15 @@ void CFogOfWar::AdjustToViewport(const CViewport &viewport)
 void CFogOfWar::Clean()
 {
     FogTexture.clear();
+    FogTextureWidth = 0;
+    FogTextureHeight = 0;
+   
     SDL_FreeSurface(WorkSurface); /// It is safe to pass NULL to this function.
     WorkSurface = nullptr;
     SDL_FreeSurface(FogSurface); /// It is safe to pass NULL to this function.
     FogSurface = nullptr;
+   
+    Blurer.Clean();
 }
 
 /**
@@ -411,6 +416,16 @@ void CBlurer::Setup(const uint16_t textureWidth, const uint16_t textureHeight)
     WorkingTexture.resize(TextureWidth * TextureHeight);
 }
 
+/**
+**  Clean blurer
+**
+*/
+void CBlurer::Clean()
+{
+    WorkingTexture.clear();
+    TextureWidth = 0;
+    TextureHeight = 0;
+}
 
 
 void CBlurer::Blur(uint8_t *texture)

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -401,11 +401,11 @@ void CFogOfWar::UpscaleBilinear(const uint8_t *const src, const SDL_Rect &srcRec
 
     uint32_t *const target = static_cast<uint32_t *>(renderSurface->pixels);
     
-    const int32_t xRatio = (((int32_t)srcRect.w - 1) << 16) / trgRect.w;
-    const int32_t yRatio = (((int32_t)srcRect.h - 1) << 16) / trgRect.h;
+    const int32_t xRatio = ((int32_t)srcRect.w << 16) / trgRect.w;
+    const int32_t yRatio = ((int32_t)srcRect.h << 16) / trgRect.h;
     
-    const int64_t xOffset = offset.x * xRatio;
-    const int64_t yOffset = offset.y * yRatio;
+    const int32_t xOffset = offset.x * xRatio;
+    const int32_t yOffset = offset.y * yRatio;
 
     #pragma omp parallel
     {    
@@ -417,7 +417,7 @@ void CFogOfWar::UpscaleBilinear(const uint8_t *const src, const SDL_Rect &srcRec
         const uint16_t uBound = numOfThreads > 1 ? (thisThread + 1) * renderRect.h / numOfThreads 
                                                  : renderRect.h;
 
-        size_t  trgIndex = (trgRect.y + renderRect.y + lBound) * renderSurface->w + trgRect.x + renderRect.x;
+        size_t  trgIndex = (renderRect.y + lBound) * renderSurface->w + renderRect.x;
         int64_t y        = ((int32_t)srcRect.y << 16) + lBound * yRatio + yOffset;
 
         for (size_t yTrg = lBound ; yTrg < uBound; yTrg++) {
@@ -472,11 +472,11 @@ void CFogOfWar::UpscaleSimple(const uint8_t *const src, const SDL_Rect &srcRect,
 {
     uint32_t *const target = static_cast<uint32_t *>(renderSurface->pixels);
     
-    const int32_t xRatio = (((int32_t)srcRect.w - 1) << 16) / trgRect.w;
-    const int32_t yRatio = (((int32_t)srcRect.h - 1) << 16) / trgRect.h;
+    const int32_t xRatio = ((int32_t)srcRect.w << 16) / trgRect.w;
+    const int32_t yRatio = ((int32_t)srcRect.h << 16) / trgRect.h;
     
-    const int64_t xOffset = offset.x * xRatio;
-    const int64_t yOffset = offset.y * yRatio;
+    const int32_t xOffset = offset.x * xRatio;
+    const int32_t yOffset = offset.y * yRatio;
 
     #pragma omp parallel
     {    
@@ -488,7 +488,7 @@ void CFogOfWar::UpscaleSimple(const uint8_t *const src, const SDL_Rect &srcRect,
         const uint16_t uBound = numOfThreads > 1 ? (thisThread + 1) * renderRect.h / numOfThreads 
                                                  : renderRect.h;
 
-        size_t  trgIndex = (trgRect.y + renderRect.y + lBound) * renderSurface->w + trgRect.x + renderRect.x;
+        size_t  trgIndex = (renderRect.y + lBound) * renderSurface->w + renderRect.x;
         int64_t y        = ((int32_t)srcRect.y << 16) + lBound * yRatio + yOffset;
 
         for (size_t yTrg = lBound ; yTrg < uBound; yTrg++) {
@@ -501,8 +501,7 @@ void CFogOfWar::UpscaleSimple(const uint8_t *const src, const SDL_Rect &srcRect,
 
                 const int32_t xSrc     = static_cast<int32_t> (x >> 16);
                 const size_t  srcIndex = yIndex + xSrc;
-
-                const uint8_t alpha = src[srcIndex];
+                const uint8_t alpha    = src[srcIndex];
 
                 ApplyFogTo(target[trgIndex + xTrg], alpha);
 

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -121,7 +121,7 @@ void CFogOfWar::Clean()
 */
 bool CFogOfWar::SetType(const FogOfWarTypes fowType)
 {
-	if (fowType < FogOfWarTypes::cNumOfTypes && fowType != Settings.FOW_Type) {
+	if (fowType != Settings.FOW_Type && fowType < FogOfWarTypes::cNumOfTypes) {
         if (Map.isInitialized()) {
             switch (fowType) {
                 case FogOfWarTypes::cLegacy:

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -162,7 +162,10 @@ void CFogOfWar::GenerateFog(const CPlayer &thisPlayer)
 */
 void CFogOfWar::Update(bool doAtOnce /*= false*/)
 {
-    
+    if (Settings.FOW_Type == FogOfWarTypes::cLegacy) {
+        return;
+    }
+
     FogTexture.Ease();
 
     if (Settings.NumOfEasingSteps < States::cReady) doAtOnce = true;

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -339,55 +339,6 @@ void CFogOfWar::FogUpscale4x4()
 }
 
 /**
-**  Determine upscale patterns (index in the upscale table) for Visible and Explored layers
-**
-**  @param  index       tile in the vision table 
-**  @param  visFlag     layer to determine pattern for
-**
-*/
-inline uint8_t CFogOfWar::DeterminePattern(const size_t index, const uint8_t visFlag) const
-{
-    Assert(visFlag == VisionType::cVisible || visFlag == (VisionType::cExplored | VisionType::cVisible));
-
-    uint8_t n1, n2, n3, n4;
-    size_t offset = index;
-
-    n1 = (visFlag & VisTable[offset]);
-    n2 = (visFlag & VisTable[offset + 1]);
-    offset += VisTableWidth;
-    n3 = (visFlag & VisTable[offset]);
-    n4 = (visFlag & VisTable[offset + 1]);
-    
-    n1 >>= n1 - VisionType::cExplored;
-    n2 >>= n2 - VisionType::cExplored;
-    n3 >>= n3 - VisionType::cExplored;
-    n4 >>= n4 - VisionType::cExplored;
-    
-    return ( (n1 << 3) | (n2 << 2) | (n3 << 1) | n4 );
-}
-
-
-/**
-**  Fill 4x4 sized tile in the fog texture according to the patterns
-**
-**  @param  texture         pointer to the texture to fill
-**  @param  textureWidth    width of the texture
-**  @param  index           index of the tile to fill
-**  @param  patternVisible  index int the upscale table for Visible layer
-**  @param  patternExplored index int the upscale table for Explored layer
-**
-*/
-inline void CFogOfWar::FillUpscaledRec(uint32_t *texture, const uint16_t textureWidth, size_t index, 
-                                const uint8_t patternVisible, const uint8_t patternExplored) const
-{
-    for (uint8_t scan_line = 0; scan_line < 4; scan_line++) {
-        texture[index] = UpscaleTable[patternVisible][scan_line] + UpscaleTable[patternExplored][scan_line];
-        index += textureWidth;
-    }
-}
-
-
-/**
 ** Bilinear zoom Fog Of War texture into SDL surface
 ** 
 **  @param src          Image src.

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -53,7 +53,7 @@
 --  Variables
 ----------------------------------------------------------------------------*/
 float   CBlurer::Radius {1.5};
-uint8_t CBlurer::NumOfIteratons {2};
+uint8_t CBlurer::NumOfIterations {2};
 
 std::vector<uint8_t> CBlurer::BoxRadius; 
 
@@ -368,7 +368,12 @@ void CFogOfWar::FillUpscaledRec(uint32_t *texture, const int textureWidth, intpt
 **  @param radius Radius or standard deviation
 **  @param numOfIterations Number of boxes
 */
-void CBlurer::Init(const float radius/* = 1.5*/, const uint8_t numOfIterations/* = 2*/)
+void CBlurer::Init()
+{
+    CBlurer::Init(CBlurer::Radius, CBlurer::NumOfIterations);
+}
+
+void CBlurer::Init(const float radius, const uint8_t numOfIterations)
 {
   
     float D = sqrt((12.0 * radius * radius  / numOfIterations) + 1);
@@ -387,7 +392,7 @@ void CBlurer::Init(const float radius/* = 1.5*/, const uint8_t numOfIterations/*
     }
 
     CBlurer::Radius         = radius;
-    CBlurer::NumOfIteratons = numOfIterations;
+    CBlurer::NumOfIterations = numOfIterations;
 }
 
 /**
@@ -404,8 +409,6 @@ void CBlurer::Setup(const uint16_t textureWidth, const uint16_t textureHeight)
     TextureHeight = textureHeight;
     WorkingTexture.clear();
     WorkingTexture.resize(TextureWidth * TextureHeight);
-
-    Init(CBlurer::Radius, CBlurer::NumOfIteratons);
 }
 
 

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -81,11 +81,20 @@ void CFogOfWar::Init()
 
     Blurer.Init(fogTextureWidth, fogTextureHeight, Settings.BlurRadius[Settings.UpscaleType], Settings.BlurIterations);
 
-    FogColorR = 0xFF & (Settings.FogColor >> RSHIFT);
-    FogColorG = 0xFF & (Settings.FogColor >> GSHIFT);
-    FogColorB = 0xFF & (Settings.FogColor >> BSHIFT);
+   SetFogColor(Settings.FogColor);
 
     this->State = cFirstEntry;
+}
+
+void CFogOfWar::SetFogColor(uint8_t r, uint8_t g, uint8_t b)
+{
+    SetFogColor(CColor(r, g, b));
+}
+
+void CFogOfWar::SetFogColor(CColor color)
+{
+    Settings.FogColor = color;
+    Settings.FogColorSDL = (color.R << RSHIFT) | (color.G << GSHIFT) | (color.B << BSHIFT);
 }
 
 void CFogOfWar::Clean()
@@ -515,15 +524,15 @@ void CFogOfWar::UpscaleSimple(const uint8_t *const src, const SDL_Rect &srcRect,
 
 void CFogOfWar::ApplyFogTo(uint32_t &pixel, const uint8_t alpha) 
 {
-    if (alpha == 0xFE) { pixel = this->Settings.FogColor; }
+    if (alpha == 0xFE) { pixel = this->Settings.FogColorSDL; }
     else  {
         const uint8_t r = 0xFF & (pixel >> RSHIFT);
         const uint8_t g = 0xFF & (pixel >> GSHIFT);
         const uint8_t b = 0xFF & (pixel >> BSHIFT);
 
-        const uint32_t resR = ((this->FogColorR * alpha) + (r * (0xFF - alpha))) >> 8;
-        const uint32_t resG = ((this->FogColorG * alpha) + (g * (0xFF - alpha))) >> 8;
-        const uint32_t resB = ((this->FogColorB * alpha) + (b * (0xFF - alpha))) >> 8;
+        const uint32_t resR = ((Settings.FogColor.R * alpha) + (r * (0xFF - alpha))) >> 8;
+        const uint32_t resG = ((Settings.FogColor.G * alpha) + (g * (0xFF - alpha))) >> 8;
+        const uint32_t resB = ((Settings.FogColor.B * alpha) + (b * (0xFF - alpha))) >> 8;
 
         pixel = (resR << RSHIFT) | (resG << GSHIFT) | (resB << BSHIFT);
     }

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -121,8 +121,22 @@ void CFogOfWar::Clean()
 */
 bool CFogOfWar::SetType(const FogOfWarTypes fowType)
 {
-	if (fowType < FogOfWarTypes::cNumOfTypes) {
-		Settings.FOW_Type = fowType;
+	if (fowType < FogOfWarTypes::cNumOfTypes && fowType != Settings.FOW_Type) {
+        if (Map.isInitialized()) {
+            switch (fowType) {
+                case FogOfWarTypes::cLegacy:
+                    this->Clean();
+                    Map.InitLegacyFogOfWar();
+                    break;
+                case FogOfWarTypes::cEnhanced:
+                    Map.CleanLegacyFogOfWar();
+                    this->Init();
+                    break;
+                default:
+                    break;
+            }
+        }
+    	Settings.FOW_Type = fowType;
 		return true;
 	} else {
 		return false;

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -185,6 +185,8 @@ void CFogOfWar::GenerateFog()
         }
     }
 
+    const uint8_t visibleThreshold = Map.NoFogOfWar ? 1 : 2;
+    
     #pragma omp parallel
     {
         const uint16_t thisThread   = omp_get_thread_num();
@@ -205,7 +207,7 @@ void CFogOfWar::GenerateFog()
                 const CMapField *mapField = Map.Field(mapIndex + col);
                 for (const uint8_t player : playersToRenderView) {
                     visCell = std::max<uint8_t>(visCell, mapField->playerInfo.Visible[player]); // mapField->playerInfo.TeamVisibilityState(Players[player]));
-                    if (visCell >= 2) {
+                    if (visCell >= visibleThreshold) {
                         visCell = 2;
                         break;
                     }

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -329,9 +329,9 @@ void CFogOfWar::FogUpscale4x4()
     uint32_t *const fogTexture = (uint32_t*)FogTexture.GetNext();
     
     /// Fog texture width and height in 32bit chunks
-    const size_t textureWidth  = FogTexture.GetWidth()  / 4;
-    const size_t textureHeight = FogTexture.GetHeight() / 4;
-    const size_t nextRowOffset = textureWidth * 4;
+    const uint16_t textureWidth  = FogTexture.GetWidth()  / 4;
+    const uint16_t textureHeight = FogTexture.GetHeight() / 4;
+    const uint16_t nextRowOffset = textureWidth * 4;
 
     #pragma omp parallel
     {

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -80,7 +80,7 @@ void CFogOfWar::Init()
     RenderedFog.resize(Map.Info.MapWidth * Map.Info.MapHeight * 16);
     std::fill(RenderedFog.begin(), RenderedFog.end(), 0xFF);
 
-    Blurer.Init(fogTextureWidth, fogTextureHeight, Settings.BlurRadius, Settings.BlurIterations);
+    Blurer.Init(fogTextureWidth, fogTextureHeight, Settings.BlurRadius[Settings.UpscaleType], Settings.BlurIterations);
 
     this->State = 0;
 }

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -356,7 +356,7 @@ void CFogOfWar::UpscaleBilinear(const uint8_t *src, const SDL_Rect &srcRect, con
         const int64_t yDiff         = y - (ySrc << 16);
         const int64_t one_min_yDiff = 65536 - yDiff;
         const size_t  yIndex        = ySrc * srcWidth;
-              int64_t x             = 0;
+              int64_t x             = srcRect.x << 16;
         
         for (size_t j = 0 ; j < trgRect.w; j++) {
 

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -173,9 +173,9 @@ void CFogOfWar::GenerateFog()
             uint8_t &visCell = VisTable[visIndex + col];
             visCell = 0; /// Clear it before check for players
             const CMapField *mapField = Map.Field(mapIndex + col);
-
+            /// TODO: change ThisPlayer to currently rendered player/players #RenderTargets
             for (const uint8_t player : VisionFor) {
-                visCell = std::max<uint8_t>(visCell, mapField->playerInfo.Visible[player]);
+                visCell = std::max<uint8_t>(visCell, mapField->playerInfo.TeamVisibilityState(Players[player])); // Visible[player]);
                 if (visCell >= 2) {
                     visCell = 2;
                     break;

--- a/src/map/fow.cpp
+++ b/src/map/fow.cpp
@@ -391,8 +391,10 @@ void CBlurer::Init()
 **  @param radius Radius or standard deviation
 **  @param numOfIterations Number of boxes
 */
-void CBlurer::Init(const float radius, const uint8_t numOfIterations)
+void CBlurer::Init(const float radius, const int numOfIterations)
 {
+    Assert (radius >= 0 && numOfIterations > 0);
+
     float D = sqrt((12.0 * radius * radius  / numOfIterations) + 1);
     int dL = floor(D);  
     if (dL % 2 == 0) { dL--; }

--- a/src/map/fow_utils.cpp
+++ b/src/map/fow_utils.cpp
@@ -1,0 +1,319 @@
+//       _________ __                 __
+//      /   _____//  |_____________ _/  |______     ____  __ __  ______
+//      \_____  \\   __\_  __ \__  \\   __\__  \   / ___\|  |  \/  ___/
+//      /        \|  |  |  | \// __ \|  |  / __ \_/ /_/  >  |  /\___ |
+//     /_______  /|__|  |__|  (____  /__| (____  /\___  /|____//____  >
+//             \/                  \/          \//_____/            \/
+//  ______________________                           ______________________
+//                        T H E   W A R   B E G I N S
+//         Stratagus - A free fantasy real time strategy game engine
+//
+/**@name fow_utils.cpp - The utilities for fog of war . */
+//
+//      (c) Copyright 2020 by Alyokhin
+//
+//      This program is free software; you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation; only version 2 of the License.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program; if not, write to the Free Software
+//      Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+//      02111-1307, USA.
+//
+
+//@{
+
+/*----------------------------------------------------------------------------
+--  Includes
+----------------------------------------------------------------------------*/
+
+#include <string.h>
+#include <algorithm>
+
+#include "stratagus.h"
+#include "fow_utils.h"
+
+
+/*----------------------------------------------------------------------------
+--  Defines
+----------------------------------------------------------------------------*/
+
+
+/*----------------------------------------------------------------------------
+--  Variables
+----------------------------------------------------------------------------*/
+
+
+/*----------------------------------------------------------------------------
+-- Functions
+----------------------------------------------------------------------------*/
+
+void CEasedTexture::Init(const uint16_t width, const uint16_t height, const uint8_t numOfSteps)
+{
+    Width       = width;
+    Height      = height;
+    TextureSize = Width * Height;
+
+    for (auto &frame : Frames) {
+        frame.clear();
+        frame.resize(TextureSize);
+
+        const size_t size = frame.size();
+        const uint8_t *ptr = frame.data();
+
+        std::fill(frame.begin(), frame.end(), 0xFF);
+    }
+
+    Deltas.clear();
+    Deltas.resize(TextureSize);
+    std::fill(Deltas.begin(), Deltas.end(), 0xFF);
+
+    EasingStepsNum  = numOfSteps;
+    CurrentStep     = numOfSteps;
+    isWatingForNext = true;
+}
+
+void CEasedTexture::Clean()
+{
+    for (auto &frame : Frames) {
+        frame.clear();
+    }
+    Deltas.clear();
+
+    Width           = 0;
+    Height          = 0;
+    EasingStepsNum  = 0;
+    CurrentStep     = 0;
+    isWatingForNext = false;
+}
+
+void CEasedTexture::DrawRegion(uint8_t *target, const uint16_t trgWidth, const uint16_t x0, const uint16_t y0, const SDL_Rect &srcRect)
+{
+    const uint16_t xEnd   = srcRect.x + srcRect.w;
+    
+    intptr_t trgIndex     = y0 * trgWidth + x0;
+    intptr_t textureIndex = srcRect.y * Width + srcRect.x;
+   
+    if (CurrentStep == 0 || CurrentStep == EasingStepsNum) {
+        const uint8_t currFrame = CurrentStep ? Curr : Prev;
+        const uint8_t *curr     = Frames[currFrame].data();
+  
+        for (uint16_t y = 0; y < srcRect.h; y++) {
+            std::copy_n(&curr[textureIndex], srcRect.w, &target[trgIndex]);
+            textureIndex += Width;
+            trgIndex     += trgWidth;
+        }
+    } else {
+        const uint8_t *prev   = Frames[Prev].data();
+        const int16_t *deltas = Deltas.data();
+        for (uint16_t y = 0; y < srcRect.h; y++) {
+            for (uint16_t x = 0; x < srcRect.w; x++) {
+                target[trgIndex + x] = prev[textureIndex + x] + deltas[textureIndex + x] * CurrentStep;
+            }
+            textureIndex += Width;
+            trgIndex     += trgWidth;
+        }
+    }
+}
+
+void CEasedTexture::CalcDeltas() 
+{ 
+    const uint8_t *curr   = Frames[Curr].data();
+    const uint8_t *next   = Frames[Next].data();
+
+    size_t index = 0;
+    for (int16_t &delta : Deltas)
+    {
+        delta = (static_cast <int16_t>(next[index]) - curr[index]) / EasingStepsNum;
+        index++;
+    }
+}
+
+
+
+/**
+**  Init box blurer
+**
+**  @param textureWidth width of the working texture (input/output texture also)
+**  @param textureHeight height of the working texture (input/output texture also)
+**
+*/
+void CBlurer::Init(const uint16_t textureWidth, const uint16_t textureHeight, const float radius, const int numOfIterations)
+{
+    PrecalcParameters(radius, numOfIterations);
+
+    TextureWidth  = textureWidth;
+    TextureHeight = textureHeight;
+    WorkingTexture.clear();
+    WorkingTexture.resize(TextureWidth * TextureHeight);
+}
+
+/**
+**  Init box blurer parameters (determine radiuses (box sizes) for box blur iterations)
+**  This used to set new parameters for blur algorithm
+**
+**  @param radius Radius or standard deviation
+**  @param numOfIterations Number of boxes
+*/
+void CBlurer::PrecalcParameters(const float radius, const int numOfIterations)
+{
+    //Assert (radius >= 0 && numOfIterations > 0);
+
+    Radius          = radius;
+    NumOfIterations = numOfIterations;
+
+    if (Radius * NumOfIterations == 0) { return; }
+
+    float D = sqrt((12.0 * radius * radius  / numOfIterations) + 1);
+    int dL = floor(D);  
+    if (dL % 2 == 0) { dL--; }
+    int dU = dL + 2;
+				
+    float M = (12 * radius * radius - numOfIterations * dL * dL - 4 * numOfIterations * dL - 3 * numOfIterations) / (-4 * dL - 4);
+    int m = round(M);
+
+    HalfBoxes.clear();
+    HalfBoxes.resize(numOfIterations);
+    for (uint8_t i = 0; i < numOfIterations; i++) {
+        HalfBoxes[i] = ((float)(i < m ? dL : dU) - 1) / 2;
+    }
+}
+
+/**
+**  Clean blurer
+**
+*/
+void CBlurer::Clean()
+{
+    HalfBoxes.clear();
+    WorkingTexture.clear();
+    TextureWidth  = 0;
+    TextureHeight = 0;
+}
+
+
+/**
+ ** Blur a texture (optimized for 1 chanel (alpha) textures)
+ **
+ ** @param  texture texture to blur (uint8_t)
+ **
+ */
+void CBlurer::Blur(uint8_t *texture)
+{
+    if (Radius * NumOfIterations == 0) { return; }
+    
+    uint8_t *source = texture;
+    uint8_t *target = WorkingTexture.data();
+
+    for (int i = 0; i < HalfBoxes.size(); i++){
+        if (i > 0) {
+            uint8_t *swap = source;
+            source = target;
+            target = swap;
+        }
+        ProceedIteration(source, target, HalfBoxes[i]); 
+    }
+    if (target != texture) {
+        // memcpy(texture, WorkingTexture.data(), WorkingTexture.size() * sizeof(uint8_t));
+        std::copy(WorkingTexture.begin(), WorkingTexture.end(), texture);
+    }
+}
+
+/**
+**  Proceed one iteration of box bluring
+**
+**  @param  source  source texture (which has to be blured)
+**  @param  target  target texture (where result will be)
+**  @param  radius  blur radius (box size) for current iteration
+** /// TODO: sitch to fixed point math
+**
+*/
+void CBlurer::ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t radius)
+{
+    //memcpy(target, source, WorkingTexture.size() * sizeof(uint8_t));
+    std::copy_n(&source[0], WorkingTexture.size(), target);
+
+    uint8_t *swap = source;
+    source = target;
+    target = swap; 
+
+    float iarr = 1.0 / (radius + radius + 1);
+    size_t ti, li, ri;
+    uint8_t leftBorder, rightBorder;
+    int16_t sum;
+
+    /// Horizontal blur pass
+    for (size_t i = 0; i < TextureHeight; i++) {
+
+        ti = i * TextureWidth; 
+        li = ti;
+        ri = ti + radius;
+        leftBorder  = source[ti];
+        rightBorder = source[ti + TextureWidth - 1];
+        sum         = (radius + 1) * leftBorder;
+
+        for (size_t j = 0; j < radius; j++) { 
+            sum += source[ti + j]; 
+        }
+        for (size_t j = 0; j <= radius; j++) {
+            sum += source[ri++] - leftBorder; 
+            target[ti++] = round(iarr * sum);
+        }
+        for (size_t j = radius + 1; j < TextureWidth - radius; j++) {
+            sum += source[ri++] - source[li++];
+            target[ti++] = round(sum * iarr);
+        }
+        for (size_t j = TextureWidth - radius; j < TextureWidth; j++) {
+            sum += rightBorder - source[li++];   
+            target[ti++] = round(iarr * sum);
+        }
+    }
+
+    swap = source;
+    source = target;
+    target = swap;  
+
+    /// Vertical blur pass
+    for (size_t i = 0; i < TextureWidth; i++) {
+
+        ti = i;
+        li = ti;
+        ri = ti + radius * TextureWidth;
+        leftBorder  = source[ti];
+        rightBorder = source[ti + TextureWidth * (TextureHeight - 1)];
+        sum         = (radius + 1) * leftBorder;
+
+        for (size_t j = 0; j < radius; j++) {
+            sum += source[ti + j * TextureWidth];
+        }
+        for (size_t j = 0; j <= radius ; j++) { 
+            sum += source[ri] - leftBorder;
+            target[ti] = round(iarr * sum);
+            ri += TextureWidth;
+            ti += TextureWidth;
+        }
+        for (size_t j = radius + 1; j < TextureHeight - radius; j++) { 
+            sum += source[ri] - source[li];
+            target[ti] = round(iarr * sum);
+            li += TextureWidth;
+            ri += TextureWidth;
+            ti += TextureWidth;
+        }
+        for (size_t j = TextureHeight - radius; j < TextureHeight; j++) { 
+            sum += rightBorder - source[li];
+            target[ti] = round(iarr * sum);
+            li += TextureWidth;
+            ti += TextureWidth;
+        }
+    }
+
+}
+
+
+//@}

--- a/src/map/fow_utils.cpp
+++ b/src/map/fow_utils.cpp
@@ -126,7 +126,7 @@ void CEasedTexture::PushNext(const bool forcedShowNext /*= false*/)
 {
     CalcDeltas();
     SwapFrames();
-    CurrentStep = forcedShowNext ? EasingStepsNum: 0;
+    CurrentStep = forcedShowNext ? EasingStepsNum : 0;
 }
 
 /**
@@ -179,8 +179,7 @@ void CEasedTexture::CalcDeltas()
 
     size_t index = 0;
     #pragma omp parallel for
-    for (size_t index = 0; index < TextureSize; index++)
-    {
+    for (size_t index = 0; index < TextureSize; index++) {
         Deltas[index] = (int16_t(next[index]) - curr[index]) / EasingStepsNum;
     }
 }
@@ -216,20 +215,22 @@ void CBlurer::PrecalcParameters(const float radius, const int numOfIterations)
     Radius          = radius;
     NumOfIterations = numOfIterations;
 
-    if (Radius * NumOfIterations == 0) { return; }
+    if (Radius * NumOfIterations == 0) { 
+        return; 
+    }
 
-    float D = sqrt((12.0 * radius * radius  / numOfIterations) + 1);
+    const float D = sqrt((12.0 * radius * radius  / numOfIterations) + 1);
     uint8_t dL = floor(D);  
     if (dL % 2 == 0) { dL--; }
-    uint8_t dU = dL + 2;
+    const uint8_t dU = dL + 2;
 				
-    float M = (12 * radius * radius - numOfIterations * dL * dL - 4 * numOfIterations * dL - 3 * numOfIterations) / (-4 * dL - 4);
-    uint8_t m = round(M);
+    const float M = (12.0 * radius * radius - numOfIterations * dL * dL - 4 * numOfIterations * dL - 3 * numOfIterations) / (-4 * dL - 4);
+    const uint8_t m = round(M);
 
     HalfBoxes.clear();
     HalfBoxes.resize(numOfIterations);
     for (uint8_t i = 0; i < numOfIterations; i++) {
-        HalfBoxes[i] = ((float)(i < m ? dL : dU) - 1) / 2;
+        HalfBoxes[i] = ((i < m ? dL : dU) - 1) / 2;
     }
 }
 
@@ -259,7 +260,7 @@ void CBlurer::Blur(uint8_t *const texture)
     uint8_t *source = texture;
     uint8_t *target = WorkingTexture.data();
 
-    for (uint8_t i = 0; i < HalfBoxes.size(); i++){
+    for (uint8_t i = 0; i < HalfBoxes.size(); i++) {
         if (i > 0) {
             uint8_t *const swap = source;
             source = target;

--- a/src/map/fow_utils.cpp
+++ b/src/map/fow_utils.cpp
@@ -10,7 +10,7 @@
 //
 /**@name fow_utils.cpp - The utilities for fog of war . */
 //
-//      (c) Copyright 2021 by Alyokhin
+//      (c) Copyright 2020-2021 by Alyokhin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by
@@ -181,7 +181,7 @@ void CEasedTexture::CalcDeltas()
     #pragma omp parallel for
     for (size_t index = 0; index < TextureSize; index++)
     {
-        Deltas[index] = (static_cast <int16_t>(next[index]) - curr[index]) / EasingStepsNum;
+        Deltas[index] = (int16_t(next[index]) - curr[index]) / EasingStepsNum;
     }
 }
 

--- a/src/map/fow_utils.cpp
+++ b/src/map/fow_utils.cpp
@@ -178,10 +178,10 @@ void CEasedTexture::CalcDeltas()
     const uint8_t *next   = Frames[Next].data();
 
     size_t index = 0;
-    for (int16_t &delta : Deltas)
+    #pragma omp parallel for
+    for (size_t index = 0; index < TextureSize; index++)
     {
-        delta = (static_cast <int16_t>(next[index]) - curr[index]) / EasingStepsNum;
-        index++;
+        Deltas[index] = (static_cast <int16_t>(next[index]) - curr[index]) / EasingStepsNum;
     }
 }
 

--- a/src/map/fow_utils.cpp
+++ b/src/map/fow_utils.cpp
@@ -117,12 +117,12 @@ void CEasedTexture::SetNumOfSteps (const uint8_t num)
 }
 
 /**
-**  Switch easing to new frame of the texture
+**  Switch easing to the new frame of the texture
 **
 **  @param forcedShowNext cmd to immediately show next frame without easing
 **
 */
-void CEasedTexture::PushNext(bool forcedShowNext /*= false*/)
+void CEasedTexture::PushNext(const bool forcedShowNext /*= false*/)
 {
     CalcDeltas();
     SwapFrames();
@@ -143,8 +143,8 @@ void CEasedTexture::DrawRegion(uint8_t *target, const uint16_t trgWidth, const u
 {
     const uint16_t xEnd   = srcRect.x + srcRect.w;
     
-    intptr_t trgIndex     = y0 * trgWidth + x0;
-    intptr_t textureIndex = srcRect.y * Width + srcRect.x;
+    size_t trgIndex     = y0 * trgWidth + x0;
+    size_t textureIndex = srcRect.y * Width + srcRect.x;
    
     if (CurrentStep == 0 || CurrentStep == EasingStepsNum) {
         const uint8_t currFrame = CurrentStep ? Curr : Prev;
@@ -278,7 +278,6 @@ void CBlurer::Blur(uint8_t *const texture)
 **  @param  source  source texture (which has to be blured)
 **  @param  target  target texture (where result will be)
 **  @param  radius  blur radius (box size) for current iteration
-** /// TODO: sitch to fixed point math
 **
 */
 void CBlurer::ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t radius)
@@ -300,9 +299,10 @@ void CBlurer::ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t r
         size_t ti = i * TextureWidth; 
         size_t li = ti;
         size_t ri = ti + radius;
+
         const uint8_t leftBorder  = source[ti];
         const uint8_t rightBorder = source[ti + TextureWidth - 1];
-        int16_t sum               = (radius + 1) * leftBorder;
+              int16_t sum         = (radius + 1) * leftBorder;
 
         for (size_t j = 0; j < radius; j++) { 
             sum += source[ti + j]; 
@@ -332,9 +332,10 @@ void CBlurer::ProceedIteration(uint8_t *source, uint8_t *target, const uint8_t r
         size_t ti = i;
         size_t li = ti;
         size_t ri = ti + radius * TextureWidth;
+
         const uint8_t leftBorder  = source[ti];
         const uint8_t rightBorder = source[ti + TextureWidth * (TextureHeight - 1)];
-        int16_t       sum         = (radius + 1) * leftBorder;
+              int16_t sum         = (radius + 1) * leftBorder;
 
         for (size_t j = 0; j < radius; j++) {
             sum += source[ti + j * TextureWidth];

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -557,7 +557,7 @@ void CMap::ClearTile(const Vec2i &tilePos)
 
 	const bool isOpaque = Map.Field(tilePos)->isOpaque();
 	if (isOpaque) {
-		MapRefreshUnitsSightAroundTile(tilePos, true);
+		MapRefreshUnitsSight(tilePos, true);
 		mapField.Flags &= ~MapFieldOpaque;
 	}
 	if (mapField.ForestOnMap()) {
@@ -568,7 +568,7 @@ void CMap::ClearTile(const Vec2i &tilePos)
 		RemoveWall(tilePos);
 	}
 	if (isOpaque) {
-		MapRefreshUnitsSightAroundTile(tilePos);
+		MapRefreshUnitsSight(tilePos);
 	} 	
 }
 /// Remove wood from the map.

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map.cpp - The map. */
 //
-//      (c) Copyright 1998-2006 by Lutz Sammer, Vladi Shabanski and
+//      (c) Copyright 1998-2021 by Lutz Sammer, Vladi Shabanski and
 //                                 Francois Beerten
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -336,10 +336,11 @@ void CMap::Create()
 void CMap::Init()
 {
 	switch (FogOfWar.GetType()) {
-		case FogOfWarTypes::cLegacy:   InitFogOfWar(); break;
+		case FogOfWarTypes::cLegacy:   InitLegacyFogOfWar(); break;
 		case FogOfWarTypes::cEnhanced: FogOfWar.Init(); break;
 		default: break;
 	}
+	this->isMapInitialized = true;
 }
 
 /**
@@ -366,13 +367,23 @@ void CMap::Clean()
 
 	FieldOfView.Clean();
 	
-	if (FogOfWar.GetType() == FogOfWarTypes::cEnhanced) {
-		FogOfWar.Clean();
-		
-		for (CViewport *vp = UI.Viewports; vp < UI.Viewports + UI.NumViewports; ++vp) {
-			vp->Clean();
-		}
+	switch (FogOfWar.GetType()) {
+		case FogOfWarTypes::cLegacy:   
+			CleanLegacyFogOfWar(); 
+			break;
+		case FogOfWarTypes::cEnhanced: 
+			if (FogOfWar.GetType() == FogOfWarTypes::cEnhanced) {
+				FogOfWar.Clean();
+				for (CViewport *vp = UI.Viewports; vp < UI.Viewports + UI.NumViewports; ++vp) {
+					vp->Clean();
+				}
+			}
+			break;
+		default: 
+			break;
 	}
+
+	this->isMapInitialized = false;
 }
 
 /**

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map.cpp - The map. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Vladi Shabanski and
+//      (c) Copyright 1998-2006 by Lutz Sammer, Vladi Shabanski and
 //                                 Francois Beerten
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -346,7 +346,7 @@ void CMap::Init()
 /**
 **  Cleanup the map module.
 */
-void CMap::Clean()
+void CMap::Clean(const bool isHardClean /* = false*/)
 {
 	delete[] this->Fields;
 
@@ -369,7 +369,7 @@ void CMap::Clean()
 	
 	switch (FogOfWar.GetType()) {
 		case FogOfWarTypes::cLegacy:   
-			CleanLegacyFogOfWar(); 
+			CleanLegacyFogOfWar(isHardClean); 
 			break;
 		case FogOfWarTypes::cEnhanced: 
 			if (FogOfWar.GetType() == FogOfWarTypes::cEnhanced) {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -335,9 +335,9 @@ void CMap::Create()
 */
 void CMap::Init()
 {
-	switch (CFogOfWar::GetType()) {
+	switch (FogOfWar.GetType()) {
 		case FogOfWarTypes::cLegacy:   InitFogOfWar(); break;
-		case FogOfWarTypes::cEnhanced: CFogOfWar::Init(); break;
+		case FogOfWarTypes::cEnhanced: FogOfWar.Init(); break;
 		default: break;
 	}
 }
@@ -366,8 +366,12 @@ void CMap::Clean()
 
 	FieldOfView.Clean();
 	
-	if (CFogOfWar::GetType() == FogOfWarTypes::cEnhanced) {
-		CFogOfWar::CleanCache();
+	if (FogOfWar.GetType() == FogOfWarTypes::cEnhanced) {
+		FogOfWar.Clean();
+		
+		for (CViewport *vp = UI.Viewports; vp < UI.Viewports + UI.NumViewports; ++vp) {
+			vp->Clean();
+		}
 	}
 }
 

--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_draw.cpp - The map drawing. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1999-2005 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_draw.cpp - The map drawing. */
 //
-//      (c) Copyright 1999-2005 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1999-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -46,6 +46,9 @@
 #include "video.h"
 
 
+bool CViewport::ShowGrid = false;
+
+
 CViewport::CViewport() : MapWidth(0), MapHeight(0), Unit(NULL)
 {
 	this->TopLeftPos.x = this->TopLeftPos.y = 0;
@@ -289,9 +292,9 @@ void CViewport::DrawMapBackgroundInViewport() const
 		sy += Map.Info.MapWidth;
 		dy += PixelTileSize.y;
 	}
-#ifdef DEBUG	
-	DrawMapGridInViewport();
-#endif
+	if (CViewport::isGridEnabled()) {
+		DrawMapGridInViewport();
+	}
 }
 
 /**

--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -56,6 +56,7 @@ CViewport::CViewport() : MapWidth(0), MapHeight(0), Unit(NULL)
 
 CViewport::~CViewport()
 {
+	this->Clean();
 }
 
 bool CViewport::Contains(const PixelPos &screenPos) const
@@ -439,11 +440,7 @@ void CViewport::Draw()
 	}
 	
 	/// Draw Fog of War
-	switch (CFogOfWar::GetType()) {
-		case FogOfWarTypes::cLegacy:   this->DrawMapFogOfWar(); break;
-		case FogOfWarTypes::cEnhanced: this->FogOfWar.Refresh(*this, *ThisPlayer); break;
-		default: break;
-	}
+	this->DrawMapFogOfWar();
 
 	// If there was a click missile, draw it again here above the fog
 	if (clickMissile != NULL) {

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -162,7 +162,12 @@ public:
 				return;
 			}
 
-			Assert(unit->VisCount[p]);
+			/// This could happen if shadow caster type of field of view is enabled, 
+			/// because of multiple calls for tiles in vertical/horizontal/diagonal lines
+			if(!unit->VisCount[p]) {
+				return;
+			}
+
 			unit->VisCount[p]--;
 			//  If the unit goes under of fog, this can happen for any player that
 			//  this player shares vision to. First of all, before unmarking,

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_fog.cpp - The map fog of war handling. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Vladi Shabanski,
+//      (c) Copyright 1999-2015 by Lutz Sammer, Vladi Shabanski,
 //		Russell Smith, Jimmy Salmon, Pali Rohár and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_fog.cpp - The map fog of war handling. */
 //
-//      (c) Copyright 1999-2015 by Lutz Sammer, Vladi Shabanski,
+//      (c) Copyright 1999-2021 by Lutz Sammer, Vladi Shabanski,
 //		Russell Smith, Jimmy Salmon, Pali Rohár and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -631,8 +631,7 @@ void CViewport::DrawLegacyFogOfWar() const
 */
 void CViewport::DrawEnhancedFogOfWar()
 {
-   /// TODO: Redraw to surface only if viewport state was changed
-	FogOfWar.RenderToViewPort(*this, this->FogSurface);
+    FogOfWar.RenderToViewPort(*this, this->FogSurface);
 
     SDL_Rect screenRect;
     screenRect.x = this->TopLeftPos.x;

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -144,7 +144,7 @@ public:
 			if (!unit->VisCount[p]) {
 				for (int pi = 0; pi < PlayerMax; ++pi) {
 					if ((pi == p /*player->Index*/)
-						|| player->HasMutualSharedVisionWith(Players[pi])) { 
+						|| player->HasSharedVisionWith(Players[pi])) { 
 						if (!unit->IsVisible(Players[pi])) {
 							UnitGoesOutOfFog(*unit, Players[pi]);
 						}
@@ -171,7 +171,7 @@ public:
 			if (!unit->VisCount[p]) {
 				for (int pi = 0; pi < PlayerMax; ++pi) {
 					if (pi == p/*player->Index*/ ||
-						player->HasMutualSharedVisionWith(Players[pi])) {
+						player->HasSharedVisionWith(Players[pi])) {
 						if (!unit->IsVisible(Players[pi])) {
 							UnitGoesUnderFog(*unit, Players[pi]);
 						}

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -136,19 +136,17 @@ public:
 		if (cloak != (int)unit->Type->BoolFlag[PERMANENTCLOAK_INDEX].value) {
 			return ;
 		}
-		const int p = player->Index;
+		const uint8_t p = this->player->Index;
 		if (MARK) {
 			//  If the unit goes out of fog, this can happen for any player that
 			//  this player shares vision with, and can't YET see the unit.
 			//  It will be able to see the unit after the Unit->VisCount ++
 			if (!unit->VisCount[p]) {
-				for (int pi = 0; pi < PlayerMax; ++pi) {
-					if ((pi == p /*player->Index*/)
-						|| player->HasSharedVisionWith(Players[pi])) { 
-						if (!unit->IsVisible(Players[pi])) {
-							UnitGoesOutOfFog(*unit, Players[pi]);
-						}
-					}
+				UnitGoesOutOfFog(*unit, *this->player);
+				for (const uint8_t pi : this->player->GetGaveVisionTo()) {
+					if (!unit->IsVisible(Players[pi])) {
+						UnitGoesOutOfFog(*unit, Players[pi]);
+					} 
 				}
 			}
 			unit->VisCount[p/*player->Index*/]++;
@@ -174,13 +172,11 @@ public:
 			//  every player that this player shares vision to can see the unit.
 			//  Now we have to check who can't see the unit anymore.
 			if (!unit->VisCount[p]) {
-				for (int pi = 0; pi < PlayerMax; ++pi) {
-					if (pi == p/*player->Index*/ ||
-						player->HasSharedVisionWith(Players[pi])) {
-						if (!unit->IsVisible(Players[pi])) {
-							UnitGoesUnderFog(*unit, Players[pi]);
-						}
-					}
+				UnitGoesUnderFog(*unit, *this->player);
+				for (const uint8_t pi : this->player->GetGaveVisionTo()) {
+					if (!unit->IsVisible(Players[pi])) {
+						UnitGoesUnderFog(*unit, Players[pi]);
+					} 
 				}
 			}
 		}

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -265,6 +265,7 @@ void MapUnmarkTileSight(const CPlayer &player, const unsigned int index)
 				UnitsOnTileUnmarkSeen(player, mf, 0);
 			}
 			// Check visible Tile, then deduct...
+			/// TODO: change ThisPlayer to currently rendered player/players #RenderTargets
 			if (mf.playerInfo.IsTeamVisible(*ThisPlayer)) {
 				Map.MarkSeenTile(mf);
 			}

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -631,8 +631,8 @@ void CViewport::DrawLegacyFogOfWar() const
 */
 void CViewport::DrawEnhancedFogOfWar()
 {
-    FogOfWar.RenderToViewPort(*this, this->FogSurface);
-
+    FogOfWar.RenderToViewPort(*this, TheScreen);
+/*
     SDL_Rect screenRect;
     screenRect.x = this->TopLeftPos.x;
     screenRect.y = this->TopLeftPos.y;
@@ -646,6 +646,7 @@ void CViewport::DrawEnhancedFogOfWar()
     fogRect.h = screenRect.h;
 
     SDL_BlitSurface(FogSurface, &fogRect, TheScreen, &screenRect);
+*/
 }
 
 

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -823,20 +823,23 @@ void CMap::InitLegacyFogOfWar()
 **  Note: If current type of FOW is cEnhanced it has to be called too in case of FOW type was changed during game
 **  It's safe to call this for both types of FOW. 
 */
-void CMap::CleanLegacyFogOfWar()
+void CMap::CleanLegacyFogOfWar(const bool isHardClean /*= false*/)
 {
 	VisibleTable.clear();
 
-	CGraphic::Free(Map.LegacyFogGraphic);
-	LegacyFogGraphic = nullptr;
-
+	if (isHardClean) {
+		CGraphic::Free(Map.LegacyFogGraphic);
+		LegacyFogGraphic = nullptr;
+	}
 	if (OnlyFogSurface) {
 		VideoPaletteListRemove(OnlyFogSurface);
 		SDL_FreeSurface(OnlyFogSurface);
 		OnlyFogSurface = nullptr;
 	}
-	CGraphic::Free(AlphaFogG);
-	AlphaFogG = nullptr;
+	if (AlphaFogG) {
+		CGraphic::Free(AlphaFogG);
+		AlphaFogG = nullptr;
+	}
 }
 
 //@}

--- a/src/map/map_fog.cpp
+++ b/src/map/map_fog.cpp
@@ -313,7 +313,12 @@ void MapUnmarkTileDetectCloak(const CPlayer &player, const unsigned int index)
 {
 	CMapField &mf = *Map.Field(index);
 	unsigned char *v = &mf.playerInfo.VisCloak[player.Index];
-	Assert(*v != 0);
+	///Assert(*v != 0);
+	/// This could happen if shadow caster type of field of view is enabled, 
+	/// because of multiple calls for tiles in vertical/horizontal/diagonal lines
+	if(*v == 0) {
+		return;
+	}	
 	if (*v == 1) {
 		UnitsOnTileUnmarkSeen(player, mf, 1);
 	}

--- a/src/map/map_radar.cpp
+++ b/src/map/map_radar.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_radar.cpp - The map radar handling. */
 //
-//      (c) Copyright 2004-2021 by Russell Smith and Jimmy Salmon.
+//      (c) Copyright 2004-2006 by Russell Smith and Jimmy Salmon.
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/map_radar.cpp
+++ b/src/map/map_radar.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_radar.cpp - The map radar handling. */
 //
-//      (c) Copyright 2004-2006 by Russell Smith and Jimmy Salmon.
+//      (c) Copyright 2004-2021 by Russell Smith and Jimmy Salmon.
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/map_radar.cpp
+++ b/src/map/map_radar.cpp
@@ -58,25 +58,21 @@ IsTileRadarVisible(const CPlayer &pradar, const CPlayer &punit, const CMapFieldP
 		const uint8_t *const jamming = mfp.RadarJammer;
 		uint8_t radarvision = 0;
 		// Check jamming first, if we are jammed, exit
-		for (const int i : punit.GetSharedVision()) {
-			if (i == pradar.Index) { 
+		for (const uint8_t p : punit.GetSharedVision()) {
+			if (p == pradar.Index) { 
 				continue; 
 			}
-			if (jamming[i] > 0) {
-				if (Players[i].HasSharedVisionWith(punit.Index)) {
-					return 0;
-				}
+			if (jamming[p] > 0) {
+				return 0;
 			}
 		}
 
-		for (const int i : pradar.GetSharedVision()) {
-			if (i == pradar.Index) { 
+		for (const uint8_t p : pradar.GetSharedVision()) {
+			if (p == pradar.Index) { 
 				continue; 
 			}
-			if (radar[i] > 0) {
-				if (Players[i].HasSharedVisionWith(pradar.Index)) {
-					radarvision |= radar[i];
-				}
+			if (radar[p] > 0) {
+				radarvision |= radar[p];
 			}
 		}
 		

--- a/src/map/map_wall.cpp
+++ b/src/map/map_wall.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_wall.cpp - The map wall handling. */
 //
-//      (c) Copyright 1999-2021 by Vladi Shabanski and Andrettin
+//      (c) Copyright 1999-2015 by Vladi Shabanski and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/map_wall.cpp
+++ b/src/map/map_wall.cpp
@@ -10,7 +10,7 @@
 //
 /**@name map_wall.cpp - The map wall handling. */
 //
-//      (c) Copyright 1999-2015 by Vladi Shabanski and Andrettin
+//      (c) Copyright 1999-2021 by Vladi Shabanski and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/map_wall.cpp
+++ b/src/map/map_wall.cpp
@@ -245,7 +245,7 @@ void CMap::SetWall(const Vec2i &pos, bool humanwall)
 	/// Refresh vision of nearby units in case is walls are set as opaque field
 	const bool isOpaque = FieldOfView.GetOpaqueFields() & MapFieldWall;
 	if (isOpaque) {
-		MapRefreshUnitsSightAroundTile(pos, true);
+		MapRefreshUnitsSight(pos, true);
 	}
 
 	if (humanwall) {
@@ -262,7 +262,7 @@ void CMap::SetWall(const Vec2i &pos, bool humanwall)
 	
 	/// Refresh vision of nearby units in case is walls are set as opaque field
 	if (isOpaque) {
-		MapRefreshUnitsSightAroundTile(pos);
+		MapRefreshUnitsSight(pos);
 	}
 
 	if (mf.playerInfo.IsTeamVisible(*ThisPlayer)) {

--- a/src/map/mapfield.cpp
+++ b/src/map/mapfield.cpp
@@ -10,7 +10,7 @@
 //
 /**@name mapfield.cpp - The map field. */
 //
-//      (c) Copyright 2013 by Joris Dauphin
+//      (c) Copyright 2021 by Joris Dauphin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/mapfield.cpp
+++ b/src/map/mapfield.cpp
@@ -10,7 +10,7 @@
 //
 /**@name mapfield.cpp - The map field. */
 //
-//      (c) Copyright 2021 by Joris Dauphin
+//      (c) Copyright 2013 by Joris Dauphin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/mapfield.cpp
+++ b/src/map/mapfield.cpp
@@ -290,12 +290,10 @@ unsigned char CMapFieldPlayerInfo::TeamVisibilityState(const CPlayer &player) co
 		maxVision = 1;
 	}
 	
-	for (const int i : player.GetSharedVision()) {
-		if (Players[i].HasSharedVisionWith(player.Index)) { //if the shared vision is mutual
-			maxVision = std::max<unsigned char>(maxVision, this->Visible[i]);
-			if (maxVision >= 2) {
-				return 2;
-			}
+	for (const uint8_t p : player.GetSharedVision()) {
+		maxVision = std::max<uint8_t>(maxVision, this->Visible[p]);
+		if (maxVision >= 2) {
+			return 2;
 		}
 	}
 

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_map.cpp - The map ccl functions. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Jimmy Salmon and Alyokhin
+//      (c) Copyright 1999-2005 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -365,6 +365,25 @@ static int CclSetFogOfWarType(lua_State *l)
 	return 0;
 }
 
+static int CclSetFogOfWarBlur(lua_State *l)
+{
+	LuaCheckArgs(l, 2);
+
+	float radius = LuaToFloat(l, 1);
+	if (radius < 0 ) {
+		PrintFunction();
+		fprintf(stdout, "Radius should be a positive float number, or 0.\n");
+		return 1;
+	}
+	int iterations = LuaToNumber(l, 2);	
+	if (radius <= 0 ) {
+		PrintFunction();
+		fprintf(stdout, "Number of box blur iterations should be greater than 0.\n");
+		return 1;
+	}
+	CBlurer::Init(radius, iterations);
+	return 0;
+}
 
 /**
 **  Fog of war opacity.
@@ -705,6 +724,7 @@ void MapCclRegister()
 	lua_register(Lua, "RemoveOpaqueFor", CclRemoveOpaqueFor);
 
 	lua_register(Lua, "SetFogOfWarType", CclSetFogOfWarType);
+	lua_register(Lua, "SetFogOfWarBlur", CclSetFogOfWarBlur);
 
 	lua_register(Lua, "SetFogOfWarGraphics", CclSetFogOfWarGraphics);
 	lua_register(Lua, "SetFogOfWarOpacity", CclSetFogOfWarOpacity);

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -301,6 +301,16 @@ static int CclSetFieldOfViewType(lua_State *l)
 }
 
 /**
+**  Get unit's field of view type -  ShadowCasting or SimpleRadial
+*/
+static int CclGetFieldOfViewType(lua_State *l)
+{
+	LuaCheckArgs(l, 0);
+	lua_pushinteger(l, int(FieldOfView.GetType()));
+	return 1;
+}
+
+/**
 **  Set opaque for the tile's terrain.
 **
 **  @param l  Lua state.
@@ -325,21 +335,40 @@ static int CclSetOpaqueFor(lua_State *l)
 			new_flag |= MapFieldForest;
 		} else {
 			PrintFunction();
-			fprintf(stdout, "Opaque may be set only for \"wall\", \"rock\" or \"forest\". \n");
+			fprintf(stdout, "Opaque can only be set for \"wall\", \"rock\" or \"forest\". \n");
 			return 1;
 		}
 	}
 	FieldOfView.SetOpaqueFields(FieldOfView.GetOpaqueFields() | new_flag);
 	return 0;
 }
-
 /**
-**  Remove opaque for the tile's terrain.
+**  Check opacity for the tile's terrain.
 **
 **  @param l  Lua state.
 **
-**  @return   0 for success, 1 for wrong tile's terrain;
 */
+static int CclGetIsOpaqueFor(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+
+	uint16_t flagToCheck = 0;
+	const char *flag_name = LuaToString(l, 1);
+	if (!strcmp(flag_name, "wall")) {
+		flagToCheck = MapFieldWall;
+	} else if (!strcmp(flag_name, "rock")) {
+		flagToCheck = MapFieldRocks;
+	} else if (!strcmp(flag_name, "forest")) {
+		flagToCheck = MapFieldForest;
+	} else {
+		PrintFunction();
+		fprintf(stdout, "Opaque can only be checked for \"wall\", \"rock\" or \"forest\". \n");
+	}
+
+	lua_pushboolean(l, FieldOfView.GetOpaqueFields() & flagToCheck);
+	return 1;
+}
+
 static int CclRemoveOpaqueFor(lua_State *l)
 {
 	unsigned short new_flag = 0;
@@ -358,7 +387,7 @@ static int CclRemoveOpaqueFor(lua_State *l)
 			new_flag |= MapFieldForest;
 		} else {
 			PrintFunction();
-			fprintf(stdout, "Opaque may be set only for \"wall\", \"rock\" or \"forest\". \n");
+			fprintf(stdout, "Opaque can only be removed for \"wall\", \"rock\" or \"forest\". \n");
 			return 1;
 		}
 	}
@@ -396,6 +425,17 @@ static int CclSetFogOfWarType(lua_State *l)
 	FogOfWar.SetType(new_type);
 	return 0;
 }
+
+/**
+**  Get Fog of War type - legacy or enhanced
+*/
+static int CclGetFogOfWarType(lua_State *l)
+{
+	LuaCheckArgs(l, 0);
+	lua_pushinteger (l, int(FogOfWar.GetType()));
+	return 1;
+}
+
 
 /**
 **  Set parameters for FOW blurer (radiuses and number of iterations)
@@ -441,6 +481,16 @@ static int CclSetFogOfWarBilinear(lua_State *l)
 	LuaCheckArgs(l, 1);
 	FogOfWar.EnableBilinearUpscale(LuaToBoolean(l, 1));
 	return 0;
+}
+
+/**
+**  Check if FOW bilinear upscaling enabled
+*/
+static int CclGetIsFogOfWarBilinear(lua_State *l)
+{
+	LuaCheckArgs(l, 0);
+	lua_pushboolean(l, FogOfWar.IsBilinearUpscaleEnabled());
+	return 1;
 }
 
 /**
@@ -783,12 +833,17 @@ void MapCclRegister()
 	lua_register(Lua, "GetIsMapGridEnabled", CclGetIsMapGridEnabled);
 
 	lua_register(Lua, "SetFieldOfViewType", CclSetFieldOfViewType);
+	lua_register(Lua, "GetFieldOfViewType", CclGetFieldOfViewType);
 	lua_register(Lua, "SetOpaqueFor", CclSetOpaqueFor);
 	lua_register(Lua, "RemoveOpaqueFor", CclRemoveOpaqueFor);
-
+	lua_register(Lua, "GetIsOpaqueFor", CclGetIsOpaqueFor);
+	
 	lua_register(Lua, "SetFogOfWarType", CclSetFogOfWarType);
+	lua_register(Lua, "GetFogOfWarType", CclGetFogOfWarType);
+
 	lua_register(Lua, "SetFogOfWarBlur", CclSetFogOfWarBlur);
 	lua_register(Lua, "SetFogOfWarBilinear", CclSetFogOfWarBilinear);
+	lua_register(Lua, "GetIsFogOfWarBilinear", CclGetIsFogOfWarBilinear);
 	
 	lua_register(Lua, "SetFogOfWarGraphics", CclSetFogOfWarGraphics);
 	lua_register(Lua, "SetFogOfWarOpacity", CclSetFogOfWarOpacity);

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -382,19 +382,40 @@ static int CclSetFogOfWarType(lua_State *l)
 */
 static int CclSetFogOfWarBlur(lua_State *l)
 {
-	LuaCheckArgs(l, 2);
+	LuaCheckArgs(l, 3);
 
-	float radius = LuaToFloat(l, 1);
-	if (radius <= 0 ) {
+	float radiusSimple = LuaToFloat(l, 1);
+	if (radiusSimple <= 0 ) {
 		PrintFunction();
 		fprintf(stdout, "Radius should be a positive float number. Blur is disabled.\n");
 	}
-	int iterations = LuaToNumber(l, 2);	
+
+	float radiusBilinear = LuaToFloat(l, 2);
+	if (radiusBilinear <= 0 ) {
+		PrintFunction();
+		fprintf(stdout, "Radius should be a positive float number. Blur is disabled.\n");
+	}
+
+	int iterations = LuaToNumber(l, 3);	
 	if (iterations <= 0 ) {
 		PrintFunction();
 		fprintf(stdout, "Number of box blur iterations should be greater than 0. Blur is disabled.\n");
 	}
-	FogOfWar.InitBlurer(radius, iterations);
+	FogOfWar.InitBlurer(radiusSimple, radiusBilinear, iterations);
+	return 0;
+}
+
+/**
+**  Activate FOW bilinear upscaling type  (true|false)
+**
+**  @param l  Lua state.
+**
+**  @return   0 for success, 1 for wrong type;
+*/
+static int CclSetFogOfWarBilinear(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+	FogOfWar.SetBilinearUpscale(LuaToBoolean(l, 1));
 	return 0;
 }
 
@@ -738,7 +759,8 @@ void MapCclRegister()
 
 	lua_register(Lua, "SetFogOfWarType", CclSetFogOfWarType);
 	lua_register(Lua, "SetFogOfWarBlur", CclSetFogOfWarBlur);
-
+	lua_register(Lua, "SetFogOfWarBilinear", CclSetFogOfWarBilinear);
+	
 	lua_register(Lua, "SetFogOfWarGraphics", CclSetFogOfWarGraphics);
 	lua_register(Lua, "SetFogOfWarOpacity", CclSetFogOfWarOpacity);
 	lua_register(Lua, "SetFogOfWarColor", CclSetFogOfWarColor);

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -247,6 +247,30 @@ static int CclSetMinimapTerrain(lua_State *l)
 }
 
 /**
+**  Activate map grid  (true|false)
+**
+**  @param l  Lua state.
+**
+**  @return   0 for success, 1 for wrong type;
+*/
+static int CclSetEnableMapGrid(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+	CViewport::EnableGrid(LuaToBoolean(l, 1));
+	return 0;
+}
+
+/**
+**  Check if map grid is enabled
+*/
+static int CclGetIsMapGridEnabled(lua_State *l)
+{
+	LuaCheckArgs(l, 0);
+	lua_pushboolean(l, CViewport::isGridEnabled());
+	return 1;
+}
+
+/**
 **  Select unit's field of view algorithm -  ShadowCasting or SimpleRadial
 **
 **  @param l  Lua state.
@@ -754,6 +778,9 @@ void MapCclRegister()
 	lua_register(Lua, "SetFogOfWar", CclSetFogOfWar);
 	lua_register(Lua, "GetFogOfWar", CclGetFogOfWar);
 	lua_register(Lua, "SetMinimapTerrain", CclSetMinimapTerrain);
+
+	lua_register(Lua, "SetEnableMapGrid", CclSetEnableMapGrid);
+	lua_register(Lua, "GetIsMapGridEnabled", CclGetIsMapGridEnabled);
 
 	lua_register(Lua, "SetFieldOfViewType", CclSetFieldOfViewType);
 	lua_register(Lua, "SetOpaqueFor", CclSetOpaqueFor);

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_map.cpp - The map ccl functions. */
 //
-//      (c) Copyright 1999-2005 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1999-2021 by Lutz Sammer, Jimmy Salmon and Alyokhin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -262,8 +262,8 @@ static int CclSetFieldOfViewType(lua_State *l)
 	if (!strcmp(type_name, "shadow-casting")) {
 		new_type = FieldOfViewTypes::cShadowCasting;
 		/// Legacy type of FOW doesn't work with shadow casting
-		if (CFogOfWar::GetType() == FogOfWarTypes::cLegacy) {
-			CFogOfWar::SetType(FogOfWarTypes::cEnhanced);
+		if (FogOfWar.GetType() == FogOfWarTypes::cLegacy) {
+			FogOfWar.SetType(FogOfWarTypes::cEnhanced);
 		}	
 	} else if (!strcmp(type_name, "simple-radial")) {
 		new_type = FieldOfViewTypes::cSimpleRadial;
@@ -369,7 +369,7 @@ static int CclSetFogOfWarType(lua_State *l)
 		fprintf(stdout, "Accessible Fog of War types: \"legacy\", \"enhanced\".\n");
 		return 1;
 	}
-	CFogOfWar::SetType(new_type);
+	FogOfWar.SetType(new_type);
 	return 0;
 }
 
@@ -385,18 +385,16 @@ static int CclSetFogOfWarBlur(lua_State *l)
 	LuaCheckArgs(l, 2);
 
 	float radius = LuaToFloat(l, 1);
-	if (radius < 0 ) {
-		PrintFunction();
-		fprintf(stdout, "Radius should be a positive float number, or 0.\n");
-		return 1;
-	}
-	int iterations = LuaToNumber(l, 2);	
 	if (radius <= 0 ) {
 		PrintFunction();
-		fprintf(stdout, "Number of box blur iterations should be greater than 0.\n");
-		return 1;
+		fprintf(stdout, "Radius should be a positive float number. Blur is disabled.\n");
 	}
-	CBlurer::Init(radius, iterations);
+	int iterations = LuaToNumber(l, 2);	
+	if (iterations <= 0 ) {
+		PrintFunction();
+		fprintf(stdout, "Number of box blur iterations should be greater than 0. Blur is disabled.\n");
+	}
+	FogOfWar.InitBlurer(radius, iterations);
 	return 0;
 }
 

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -261,6 +261,10 @@ static int CclSetFieldOfViewType(lua_State *l)
 	const char *type_name = LuaToString(l, 1);
 	if (!strcmp(type_name, "shadow-casting")) {
 		new_type = FieldOfViewTypes::cShadowCasting;
+		/// Legacy type of FOW doesn't work with shadow casting
+		if (CFogOfWar::GetType() == FogOfWarTypes::cLegacy) {
+			CFogOfWar::SetType(FogOfWarTypes::cEnhanced);
+		}	
 	} else if (!strcmp(type_name, "simple-radial")) {
 		new_type = FieldOfViewTypes::cSimpleRadial;
 	} else {
@@ -354,6 +358,10 @@ static int CclSetFogOfWarType(lua_State *l)
 	const char *type_name = LuaToString(l, 1);
 	if (!strcmp(type_name, "legacy")) {
 		new_type = FogOfWarTypes::cLegacy;
+		/// Legacy type of FOW doesn't work with shadow casting
+		if (FieldOfView.GetType() == FieldOfViewTypes::cShadowCasting) {
+			FieldOfView.SetType(FieldOfViewTypes::cSimpleRadial);
+		}
 	} else if (!strcmp(type_name, "enhanced")) {
 		new_type = FogOfWarTypes::cEnhanced;
 	} else {

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -374,7 +374,7 @@ static int CclSetFogOfWarType(lua_State *l)
 }
 
 /**
-**  Set parameters for FOW blurer (radius and number of iterations)
+**  Set parameters for FOW blurer (radiuses and number of iterations)
 **
 **  @param l  Lua state.
 **
@@ -415,7 +415,7 @@ static int CclSetFogOfWarBlur(lua_State *l)
 static int CclSetFogOfWarBilinear(lua_State *l)
 {
 	LuaCheckArgs(l, 1);
-	FogOfWar.SetBilinearUpscale(LuaToBoolean(l, 1));
+	FogOfWar.EnableBilinearUpscale(LuaToBoolean(l, 1));
 	return 0;
 }
 

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -485,6 +485,8 @@ static int CclSetFogOfWarColor(lua_State *l)
 	FogOfWarColor.G = g;
 	FogOfWarColor.B = b;
 
+	FogOfWar.SetFogColor(r, g, b);
+
 	return 0;
 }
 

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -813,6 +813,30 @@ static int CclGetTileTerrainHasFlag(lua_State *l)
 }
 
 /**
+**  Enable walls enabled for single player games (for debug purposes)
+**
+**  @param l  Lua state.
+**
+**  @return   0 for success, 1 for wrong type;
+*/
+static int CclSetEnableWallsForSP(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+	EnableWallsInSinglePlayer = LuaToBoolean(l, 1);
+	return 0;
+}
+
+/**
+**  Check if walls enabled for single player games (for debug purposes)
+*/
+static int CclIsWallsEnabledForSP(lua_State *l)
+{
+	LuaCheckArgs(l, 0);
+	lua_pushboolean(l, EnableWallsInSinglePlayer);
+	return 1;
+}
+
+/**
 **  Register CCL features for map.
 */
 void MapCclRegister()
@@ -860,6 +884,9 @@ void MapCclRegister()
 
 	lua_register(Lua, "GetTileTerrainName", CclGetTileTerrainName);
 	lua_register(Lua, "GetTileTerrainHasFlag", CclGetTileTerrainHasFlag);
+
+	lua_register(Lua, "SetEnableWallsForSP", CclSetEnableWallsForSP);
+	lua_register(Lua, "GetIsWallsEnabledForSP", CclIsWallsEnabledForSP);
 }
 
 //@}

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -365,6 +365,13 @@ static int CclSetFogOfWarType(lua_State *l)
 	return 0;
 }
 
+/**
+**  Set parameters for FOW blurer (radius and number of iterations)
+**
+**  @param l  Lua state.
+**
+**  @return   0 for success, 1 for wrong type;
+*/
 static int CclSetFogOfWarBlur(lua_State *l)
 {
 	LuaCheckArgs(l, 2);

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -501,10 +501,10 @@ static int CclSetFogOfWarGraphics(lua_State *l)
 
 	LuaCheckArgs(l, 1);
 	FogGraphicFile = LuaToString(l, 1);
-	if (CMap::FogGraphic) {
-		CGraphic::Free(CMap::FogGraphic);
+	if (CMap::LegacyFogGraphic) {
+		CGraphic::Free(CMap::LegacyFogGraphic);
 	}
-	CMap::FogGraphic = CGraphic::New(FogGraphicFile, PixelTileSize.x, PixelTileSize.y);
+	CMap::LegacyFogGraphic = CGraphic::New(FogGraphicFile, PixelTileSize.x, PixelTileSize.y);
 
 	return 0;
 }

--- a/src/map/script_tileset.cpp
+++ b/src/map/script_tileset.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_tileset.cpp - The tileset ccl functions. */
 //
-//      (c) Copyright 2000-2007 by Lutz Sammer, Francois Beerten and Jimmy Salmon
+//      (c) Copyright 2000-2021 by Lutz Sammer, Francois Beerten and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/map/script_tileset.cpp
+++ b/src/map/script_tileset.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_tileset.cpp - The tileset ccl functions. */
 //
-//      (c) Copyright 2000-2021 by Lutz Sammer, Francois Beerten and Jimmy Salmon
+//      (c) Copyright 2000-2007 by Lutz Sammer, Francois Beerten and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/network/commands.cpp
+++ b/src/network/commands.cpp
@@ -10,7 +10,7 @@
 //
 /**@name commands.cpp - Global command handler - network support. */
 //
-//      (c) Copyright 2000-2007 by Lutz Sammer, Andreas Arens, and Jimmy Salmon.
+//      (c) Copyright 2000-2021 by Lutz Sammer, Andreas Arens, and Jimmy Salmon.
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/network/commands.cpp
+++ b/src/network/commands.cpp
@@ -38,6 +38,7 @@
 #include "commands.h"
 
 #include "actions.h"
+#include "fov.h"
 #include "net_message.h"
 #include "network.h"
 #include "replay.h"
@@ -801,6 +802,34 @@ void ExecExtendedCommand(unsigned char type, int status,
 				CommandLog("shared-vision", NoUnitP, 0, arg2, arg4, NoUnitP, "1", -1);
 			}
 			CommandSharedVision(arg2, arg3 ? true : false, arg4);
+			break;
+		case ExtendedMessageAutoTargetingDB:
+			/// arg1: 0:true / 1:false
+			if (arg1 == 0 || arg1 == 1) {
+				Preference.SimplifiedAutoTargeting = arg1 ? true : false;
+				/// CommandLog(...);
+			} else {
+				/// CommandLog(...);
+			}
+			break;
+		case ExtendedMessageFieldOfViewDB:
+			{
+				/// arg1: 0:cShadowCasting / 1:cSimpleRadial
+				FieldOfViewTypes fovType = arg1 == 0 ? FieldOfViewTypes::cShadowCasting
+										 : arg1 == 1 ? FieldOfViewTypes::cSimpleRadial
+													 : FieldOfViewTypes::NumOfTypes;
+				if (fovType < FieldOfViewTypes::NumOfTypes) {
+					FieldOfView.SetType(fovType);
+					/// CommandLog(...);
+				} else {
+					/// CommandLog(...);
+				}
+			}
+			break;
+		case ExtendedMessageMapFieldsOpacityDB:
+			/// Arg2: Opaque fields flags
+			FieldOfView.SetOpaqueFields(arg2);
+			/// CommandLog(...);
 			break;
 		default:
 			DebugPrint("Unknown extended message %u/%s %u %u %u %u\n" _C_

--- a/src/network/commands.cpp
+++ b/src/network/commands.cpp
@@ -10,7 +10,7 @@
 //
 /**@name commands.cpp - Global command handler - network support. */
 //
-//      (c) Copyright 2000-2021 by Lutz Sammer, Andreas Arens, and Jimmy Salmon.
+//      (c) Copyright 2000-2007 by Lutz Sammer, Andreas Arens, and Jimmy Salmon.
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/spell/spell_demolish.cpp
+++ b/src/spell/spell_demolish.cpp
@@ -10,7 +10,7 @@
 //
 /**@name spell_demolish.cpp - The spell demolish. */
 //
-//      (c) Copyright 1998-2021 by Vladi Belperchinov-Shabanski, Lutz Sammer,
+//      (c) Copyright 1998-2012 by Vladi Belperchinov-Shabanski, Lutz Sammer,
 //                                 Jimmy Salmon, and Joris DAUPHIN
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/spell/spell_demolish.cpp
+++ b/src/spell/spell_demolish.cpp
@@ -10,7 +10,7 @@
 //
 /**@name spell_demolish.cpp - The spell demolish. */
 //
-//      (c) Copyright 1998-2012 by Vladi Belperchinov-Shabanski, Lutz Sammer,
+//      (c) Copyright 1998-2021 by Vladi Belperchinov-Shabanski, Lutz Sammer,
 //                                 Jimmy Salmon, and Joris DAUPHIN
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/stratagus/mainloop.cpp
+++ b/src/stratagus/mainloop.cpp
@@ -368,8 +368,6 @@ static void DisplayLoop()
 		// program, as we now still have a game on the background and
 		// need to go through the game-menu or supply a map file
 
-		/// TODO: if FastForwardCycle then do full update cycle at once, and disable texture easing 
-		///  FogOfWar.Update(true);
 		FogOfWar.Update(FastForwardCycle > GameCycle ? true : false);
 
 		UpdateDisplay();

--- a/src/stratagus/mainloop.cpp
+++ b/src/stratagus/mainloop.cpp
@@ -10,7 +10,7 @@
 //
 /**@name mainloop.cpp - The main game loop. */
 //
-//      (c) Copyright 1998-2006 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/stratagus/mainloop.cpp
+++ b/src/stratagus/mainloop.cpp
@@ -10,7 +10,7 @@
 //
 /**@name mainloop.cpp - The main game loop. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 1998-2006 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/stratagus/mainloop.cpp
+++ b/src/stratagus/mainloop.cpp
@@ -56,6 +56,16 @@
 #include <guichan.h>
 void DrawGuichanWidgets();
 
+
+enum CallPeriod { cEvery2nd   = 0b1, 
+				  cEvery4th   = 0b11, 
+				  cEvery8th   = 0b111, 
+				  cEvery16th  = 0b1111, 
+				  cEvery32nd  = 0b11111, 
+				  cEvery64th  = 0b111111, 
+				  cEvery128th = 0b1111111,
+				  cEvery256th = 0b11111111 };
+
 //----------------------------------------------------------------------------
 // Variables
 //----------------------------------------------------------------------------
@@ -148,11 +158,6 @@ void DoScrollArea(int state, bool fast, bool isKeyboard)
 */
 void DrawMapArea()
 {
-	/// Reset VisionCache
-	if (CFogOfWar::GetType() == FogOfWarTypes::cEnhanced) {
-		CFogOfWar::ResetCache();
-	}
-
 	// Draw all of the viewports
 	for (CViewport *vp = UI.Viewports; vp < UI.Viewports + UI.NumViewports; ++vp) {
 		// Center viewport on tracked unit
@@ -313,7 +318,7 @@ static void GameLogicLoop()
 	ParticleManager.update(); // handle particles
 	CheckMusicFinished(); // Check for next song
 
-	if (FastForwardCycle <= GameCycle || !(GameCycle & 0xff)) {
+	if (FastForwardCycle <= GameCycle || !(GameCycle & CallPeriod::cEvery256th)) {
 		WaitEventsOneFrame();
 	}
 
@@ -358,10 +363,15 @@ static void DisplayLoop()
 		VideoSyncSpeed = 3000;
 	}
 #endif
-	if (FastForwardCycle <= GameCycle || GameCycle <= 10 || !(GameCycle & 0xff)) {
+	if (FastForwardCycle <= GameCycle || GameCycle <= 10 || !(GameCycle & CallPeriod::cEvery256th)) {
 		//FIXME: this might be better placed somewhere at front of the
 		// program, as we now still have a game on the background and
 		// need to go through the game-menu or supply a map file
+
+		/// TODO: if FastForwardCycle then do full update cycle at once, and disable texture easing 
+		///  FogOfWar.Update(true);
+		FogOfWar.Update(FastForwardCycle > GameCycle ? true : false);
+
 		UpdateDisplay();
 		RealizeVideoMemory();
 	}

--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -10,7 +10,7 @@
 //
 /**@name player.cpp - The players. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
 //		and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/stratagus/player.cpp
+++ b/src/stratagus/player.cpp
@@ -10,7 +10,7 @@
 //
 /**@name player.cpp - The players. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
 //		and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/stratagus/script.cpp
+++ b/src/stratagus/script.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script.cpp - The configuration language. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Joris Dauphin.
+//      (c) Copyright 1998-2007 by Lutz Sammer, Jimmy Salmon and Joris Dauphin.
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/stratagus/script.cpp
+++ b/src/stratagus/script.cpp
@@ -347,6 +347,21 @@ int LuaToNumber(lua_State *l, int narg)
 }
 
 /**
+**  Convert lua number in C float.
+**  It checks also type and exit in case of error.
+**
+**  @param l     Lua state.
+**  @param narg  Argument number.
+**
+**  @return      C number from lua.
+*/
+float LuaToFloat(lua_State *l, int narg)
+{
+	luaL_checktype(l, narg, LUA_TNUMBER);
+	return static_cast<float>(lua_tonumber(l, narg));
+}
+
+/**
 **  Convert lua number in C unsigned int.
 **  It checks also type and exit in case of error.
 **

--- a/src/stratagus/script.cpp
+++ b/src/stratagus/script.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script.cpp - The configuration language. */
 //
-//      (c) Copyright 1998-2007 by Lutz Sammer, Jimmy Salmon and Joris Dauphin.
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Joris Dauphin.
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -152,10 +152,13 @@ void CPlayer::Load(lua_State *l)
 		} else if (!strcmp(value, "shared-vision")) {
 			value = LuaToString(l, j + 1);
 			for (int i = 0; i < PlayerMax && *value; ++i, ++value) {
+				if (i == this->Index) {
+					continue;
+				}
 				if (*value == '-' || *value == '_' || *value == ' ') {
-					this->SharedVision.erase(i);
+					this->UnshareVisionWith(Players[i]);
 				} else {
-					this->SharedVision.insert(i);
+					this->ShareVisionWith(Players[i]);
 				}
 			}
 		} else if (!strcmp(value, "start")) {

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_player.cpp - The player ccl functions. */
 //
-//      (c) Copyright 2001-2021 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 2001-2007 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/stratagus/script_player.cpp
+++ b/src/stratagus/script_player.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_player.cpp - The player ccl functions. */
 //
-//      (c) Copyright 2001-2007 by Lutz Sammer and Jimmy Salmon
+//      (c) Copyright 2001-2021 by Lutz Sammer and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -10,7 +10,7 @@
 //
 /**@name stratagus.cpp - The main file. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Francois Beerten,
+//      (c) Copyright 1998-2015 by Lutz Sammer, Francois Beerten,
 //                                 Jimmy Salmon, Pali Rohár and cybermind
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -10,7 +10,7 @@
 //
 /**@name stratagus.cpp - The main file. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Francois Beerten,
+//      (c) Copyright 1998-2021 by Lutz Sammer, Francois Beerten,
 //                                 Jimmy Salmon, Pali Rohár and cybermind
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -248,10 +248,12 @@ bool EnableAssert;               /// if enabled, halt on assertion failures
 bool EnableUnitDebug;            /// if enabled, a unit info dump will be created
 
 #ifdef DEBUG
-bool IsDebugEnabled {true};      /// Is debug enaled? Flag to pass into lua code. 
+bool IsDebugEnabled {true};      /// Is debug enabled? Flag to pass into lua code. 
 #else
-bool IsDebugEnabled {false};     /// Is debug enaled? Flag to pass into lua code.
+bool IsDebugEnabled {false};     /// Is debug enabled? Flag to pass into lua code.
 #endif
+bool EnableWallsInSinglePlayer {false}; /// Enables ability to build walls in the single player games
+										/// used for debug purposes
 
 /*============================================================================
 ==  MAIN

--- a/src/tolua/player.pkg
+++ b/src/tolua/player.pkg
@@ -59,9 +59,6 @@ class CPlayer
 	bool IsAllied(const CPlayer &player) const;
 	bool IsAllied(const CUnit &unit) const;
 	bool HasSharedVisionWith(const CPlayer &player) const;
-	bool HasSharedVisionWith(const CUnit &unit) const;
-	bool HasMutualSharedVisionWith(const CPlayer &player) const;
-	bool HasMutualSharedVisionWith(const CUnit &unit) const;
 	bool IsTeamed(const CPlayer &player) const;
 	bool IsTeamed(const CUnit &unit) const;
 };

--- a/src/tolua/video.pkg
+++ b/src/tolua/video.pkg
@@ -23,6 +23,7 @@ class CGraphic
 {
 public:
 	static CGraphic *New(const std::string file, int w = 0, int h = 0);
+	static CGraphic *ForceNew(const std::string file, int w = 0, int h = 0);
 	static CGraphic *Get(const std::string file);
 	static void Free(CGraphic *);
 	void Load();

--- a/src/ui/button_checks.cpp
+++ b/src/ui/button_checks.cpp
@@ -10,7 +10,7 @@
 //
 /**@name button_checks.cpp - The button checks. */
 //
-//      (c) Copyright 1999-2015 by Lutz Sammer, Vladi Belperchinov-Shabanski
+//      (c) Copyright 1999-2021 by Lutz Sammer, Vladi Belperchinov-Shabanski
 //      and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/ui/button_checks.cpp
+++ b/src/ui/button_checks.cpp
@@ -10,7 +10,7 @@
 //
 /**@name button_checks.cpp - The button checks. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Vladi Belperchinov-Shabanski
+//      (c) Copyright 1999-2015 by Lutz Sammer, Vladi Belperchinov-Shabanski
 //      and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/ui/button_checks.cpp
+++ b/src/ui/button_checks.cpp
@@ -364,4 +364,22 @@ bool ButtonCheckSingleResearch(const CUnit &unit, const ButtonAction &button)
 	return false;
 }
 
+/**
+**  Check for button enabled, if requested condition passes check
+**  Used for debug purposes
+**
+**  @param unit    Pointer to unit for button.
+**  @param button  Pointer to button to check/enable.
+**
+**  @return        True if check passed.
+**
+*/
+bool ButtonCheckDebug(const CUnit &, const ButtonAction &button)
+{
+	if(!button.AllowStr.compare("single-player-walls")) { /// Check if enabled walls for singleplayer games
+		return !IsNetworkGame() && EnableWallsInSinglePlayer;
+	}
+	return false;
+}
+
 //@}

--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -10,7 +10,7 @@
 //
 /**@name mouse.cpp - The mouse handling. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -10,7 +10,7 @@
 //
 /**@name mouse.cpp - The mouse handling. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/ui/mouse.cpp
+++ b/src/ui/mouse.cpp
@@ -1028,7 +1028,7 @@ void UIHandleMouseMove(const PixelPos &cursorPos)
 			CMapField &mf = *Map.Field(tilePos);
 			for (int i = 0; i < PlayerMax; ++i) {
 				if (mf.playerInfo.IsExplored(Players[i])
-					&& (i == ThisPlayer->Index || Players[i].HasMutualSharedVisionWith(*ThisPlayer))) {
+					&& (i == ThisPlayer->Index || Players[i].HasSharedVisionWith(*ThisPlayer))) {
 					show = true;
 					break;
 				}

--- a/src/ui/script_ui.cpp
+++ b/src/ui/script_ui.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_ui.cpp - The ui ccl functions. */
 //
-//      (c) Copyright 1999-2015 by Lutz Sammer, Jimmy Salmon, Martin Renold
+//      (c) Copyright 1999-2021 by Lutz Sammer, Jimmy Salmon, Martin Renold
 //      and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/ui/script_ui.cpp
+++ b/src/ui/script_ui.cpp
@@ -1032,6 +1032,8 @@ static int CclDefineButton(lua_State *l)
 				ba.Allowed = ButtonCheckResearch;
 			} else if (!strcmp(value, "check-single-research")) {
 				ba.Allowed = ButtonCheckSingleResearch;
+			} else if (!strcmp(value, "check-debug")) {
+				ba.Allowed = ButtonCheckDebug;
 			} else {
 				LuaError(l, "Unsupported action: %s" _C_ value);
 			}

--- a/src/ui/script_ui.cpp
+++ b/src/ui/script_ui.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_ui.cpp - The ui ccl functions. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Jimmy Salmon, Martin Renold
+//      (c) Copyright 1999-2015 by Lutz Sammer, Jimmy Salmon, Martin Renold
 //      and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/unit/script_unit.cpp
+++ b/src/unit/script_unit.cpp
@@ -42,6 +42,8 @@
 #include "construct.h"
 #include "interface.h"
 #include "map.h"
+#include "netconnect.h"
+#include "network.h"
 #include "pathfinder.h"
 #include "player.h"
 #include "script.h"
@@ -1282,6 +1284,26 @@ static int CclSelectSingleUnit(lua_State *l)
 }
 
 /**
+**  Enable/disable simplified auto targeting 
+**
+**  @param l  Lua state.
+**
+**  @return   0 for success, 1 for wrong type;
+*/
+static int CclEnableSimplifiedAutoTargeting(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+	const bool isSimplified = LuaToBoolean(l, 1);
+	if (!IsNetworkGame()) {
+		Preference.SimplifiedAutoTargeting = isSimplified;
+	} else {
+		NetworkSendExtendedCommand(ExtendedMessageAutoTargetingDB, 
+								   int(isSimplified), 0, 0, 0, 0);
+	}
+	return 0;
+}
+
+/**
 **  Register CCL features for unit.
 */
 void UnitCclRegister()
@@ -1315,6 +1337,7 @@ void UnitCclRegister()
 	lua_register(Lua, "SlotUsage", CclSlotUsage);
 
 	lua_register(Lua, "SelectSingleUnit", CclSelectSingleUnit);
+	lua_register(Lua, "EnableSimplifiedAutoTargeting", CclEnableSimplifiedAutoTargeting);
 }
 
 //@}

--- a/src/unit/script_unittype.cpp
+++ b/src/unit/script_unittype.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_unittype.cpp - The unit-type ccl functions. */
 //
-//      (c) Copyright 1999-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1999-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/unit/script_unittype.cpp
+++ b/src/unit/script_unittype.cpp
@@ -10,7 +10,7 @@
 //
 /**@name script_unittype.cpp - The unit-type ccl functions. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1999-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -796,7 +796,7 @@ CUnit *MakeUnit(const CUnitType &type, CPlayer *player)
 **  @param width   Width of the first container of unit.
 **  @param height  Height of the first container of unit.
 **  @param f       Function to (un)mark for normal vision.
-**  @param f2        Function to (un)mark for cloaking vision.
+**  @param f2      Function to (un)mark for cloaking vision.
 */
 static void MapMarkUnitSightRec(const CUnit &unit, const Vec2i &pos, int width, int height,
 								MapMarkerFunc *f, MapMarkerFunc *f2)

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -10,7 +10,7 @@
 //
 /**@name unit.cpp - The units. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -901,7 +901,7 @@ void MapUnmarkUnitSight(CUnit &unit)
 **
 **  @see MapUnmarkUnitSight/MapMarkUnitSight
 */
-void MapRefreshUnitsSightAroundTile(const Vec2i &tilePos, const bool resetSight /*= false*/)
+void MapRefreshUnitsSight(const Vec2i &tilePos, const bool resetSight /*= false*/)
 {
 	const CMapField *mapField = Map.Field(tilePos);
 	for (const CPlayer &player : Players) {
@@ -919,6 +919,26 @@ void MapRefreshUnitsSightAroundTile(const Vec2i &tilePos, const bool resetSight 
 						MapMarkUnitSight(*unit);
 					}
 				}
+			}
+		}
+	}
+}
+
+/**
+**  Mark/Unmark on vision table the Sight for all units on the map
+**
+**  @param resetSight Unmark sight if True, Mark otherwise
+**
+**  @see MapUnmarkUnitSight/MapMarkUnitSight
+*/
+void MapRefreshUnitsSight(const bool resetSight /*= false*/)
+{
+	for (CUnit *const unit : UnitManager.GetUnits()) {
+		if (!unit->Destroyed) {
+			if (resetSight) {
+				MapUnmarkUnitSight(*unit);
+			} else {
+				MapMarkUnitSight(*unit);
 			}
 		}
 	}

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -10,7 +10,7 @@
 //
 /**@name unit.cpp - The units. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon and Andrettin
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -1711,11 +1711,9 @@ bool CUnit::IsVisible(const CPlayer &player) const
 	if (this->VisCount[player.Index]) {
 		return true;
 	}
-	for (const int p : player.GetSharedVision()) {
+	for (const uint8_t p : player.GetSharedVision()) {
 		if (this->VisCount[p]) {
-			if (Players[p].HasSharedVisionWith(player.Index)) {	//if the shared vision is mutual	
-				return true;
-			}
+			return true;
 		}
 	}
 
@@ -3342,46 +3340,6 @@ bool CUnit::IsAllied(const CPlayer &player) const
 bool CUnit::IsAllied(const CUnit &unit) const
 {
 	return IsAllied(*unit.Player);
-}
-
-/**
-**  Check if unit shares vision with the player
-**
-**  @param x  Player to check
-*/
-bool CUnit::HasSharedVisionWith(const CPlayer &player) const
-{
-	return this->Player->HasSharedVisionWith(player);
-}
-
-/**
-**  Check if the unit shares vision with the unit
-**
-**  @param x  Unit to check
-*/
-bool CUnit::HasSharedVisionWith(const CUnit &unit) const
-{
-	return this->HasSharedVisionWith(*unit.Player);
-}
-
-/**
-**  Check if both players share vision
-**
-**  @param x  Player to check
-*/
-bool CUnit::HasMutualSharedVisionWith(const CPlayer &player) const
-{
-	return this->Player->HasMutualSharedVisionWith(player);
-}
-
-/**
-**  Check if both units share vision
-**
-**  @param x  Unit to check
-*/
-bool CUnit::HasMutualSharedVisionWith(const CUnit &unit) const
-{
-	return this->HasMutualSharedVisionWith(*unit.Player);
 }
 
 /**

--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -10,7 +10,7 @@
 //
 /**@name unit_draw.cpp - The draw routines for units. */
 //
-//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
+//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
 //		and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -10,7 +10,7 @@
 //
 /**@name unit_draw.cpp - The draw routines for units. */
 //
-//      (c) Copyright 1998-2021 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
+//      (c) Copyright 1998-2015 by Lutz Sammer, Jimmy Salmon, Nehal Mistry
 //		and Andrettin
 //
 //      This program is free software; you can redistribute it and/or modify

--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -832,7 +832,7 @@ void CUnit::Draw(const CViewport &vp) const
 	if (this->Destroyed || this->Container || this->Type->BoolFlag[REVEALER_INDEX].value) { // Revealers are not drawn
 		return;
 	}
-
+	/// TODO: change ThisPlayer to currently rendered player/players #RenderTargets
 	bool IsVisible = this->IsVisible(*ThisPlayer);
 
 	// Those should have been filtered. Check doesn't make sense with ReplayRevealMap

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -288,10 +288,10 @@ bool CVideo::ResizeScreen(int w, int h)
 		SDL_FreeSurface(TheScreen);
 	}
 	TheScreen = SDL_CreateRGBSurface(0, w, h, 32,
-									 0x00ff0000,
-									 0x0000ff00,
-									 0x000000ff,
-									 0); // 0xff000000);
+									 RMASK,
+									 GMASK,
+									 BMASK,
+									 0); // AMASK);
 	Assert(SDL_MUSTLOCK(TheScreen) == 0);
 
 	// new texture

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -10,7 +10,7 @@
 //
 /**@name video.cpp - The universal video functions. */
 //
-//      (c) Copyright 1999-2021 by Lutz Sammer, Nehal Mistry, and Jimmy Salmon
+//      (c) Copyright 1999-2005 by Lutz Sammer, Nehal Mistry, and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -10,7 +10,7 @@
 //
 /**@name video.cpp - The universal video functions. */
 //
-//      (c) Copyright 1999-2005 by Lutz Sammer, Nehal Mistry, and Jimmy Salmon
+//      (c) Copyright 1999-2021 by Lutz Sammer, Nehal Mistry, and Jimmy Salmon
 //
 //      This program is free software; you can redistribute it and/or modify
 //      it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- Implemented shadow caster field of view type, which blocks vision through opaque obstacles (f.eg. cave walls in war1gus) or certain map tiles with enabled "opaque" flag. In additional there is a possibility to enable opacity for all rocks- OR forest- OR wall-tiles. This feature makes it possible to implement sight blocking for high/low ground .
- Added "elevated" flag for units/buildings which allow them to look over opaque fields (f.eg. towers).
- Added enhanced type of fog of war, as long as original sprite-based fog can't be used when shadow caster is enabled. Also added few parameters to tune it (blur radius, number of blur iterations, number fog easing steps, bilinear interpolation).
- Field of view parameters and auto targeting algorithm can be changed simultaneously for all computers of already started network game. It prevents desync causes. Mostly useful for debug.
- Map grid is optional now and can be disabled. Actual only for debug builds.
- Optimized shared vision code.

Corresponded PRs:
https://github.com/Wargus/war1gus/pull/185
https://github.com/Wargus/wargus/pull/359
 
