### PR TITLE
Fixed issue with moving AI units to {0;0} when where is no valid rall…

### DIFF
--- a/src/ai/ai_force.cpp
+++ b/src/ai/ai_force.cpp
@@ -498,10 +498,15 @@ void AiForce::Attack(const Vec2i &pos)
 		return;
 	}
 	if (this->State == AiForceAttackingState_Waiting && isDefenceForce == false) {
-		Vec2i resultPos;
+		Vec2i resultPos {-1, -1};
 		NewRallyPoint(goalPos, &resultPos);
-		this->GoalPos = resultPos;
-		this->State = AiForceAttackingState_GoingToRallyPoint;
+		if (resultPos.x != -1 && resultPos.y != -1) {
+			this->GoalPos = resultPos;
+			this->State = AiForceAttackingState_GoingToRallyPoint;
+		} else {
+			this->GoalPos = goalPos;
+			this->State = AiForceAttackingState_Attacking;
+		}
 	} else {
 		this->GoalPos = goalPos;
 		this->State = AiForceAttackingState_Attacking;
@@ -1094,10 +1099,15 @@ void AiForce::Update()
 			State = AiForceAttackingState_Waiting;
 			return;
 		} else {
-			Vec2i resultPos;
+			Vec2i resultPos {-1, -1};
 			NewRallyPoint(unit->tilePos, &resultPos);
-			this->GoalPos = resultPos;
-			this->State = AiForceAttackingState_GoingToRallyPoint;
+			if (resultPos.x != -1 && resultPos.y != -1) {
+				this->GoalPos = resultPos;
+				this->State = AiForceAttackingState_GoingToRallyPoint;
+			} else {
+				this->GoalPos = unit->tilePos;
+				this->State = AiForceAttackingState_Attacking;
+			}
 		}
 	}
 	for (size_t i = 0; i != idleUnits.size(); ++i) {


### PR DESCRIPTION
…y point.

@SimoneStarace:
> I will explain to you my problem. I don't understand why but when the A.I has to attack with ships it must bring the ships at position {0,0} and then the ships attacks. This is a problem for maps where the A.I has a base on the top left of the map. Basically it never attacks.

from here: 
https://discord.com/channels/780082494447288340/780082494447288344/843903388579004462

Solution provided by @Andrettin 
