### PR TITLE
Add optimization to not draw text when text is empty 

### DIFF
--- a/gameheaders/stratagus-game-launcher.h
+++ b/gameheaders/stratagus-game-launcher.h
@@ -237,6 +237,7 @@ int check_version(char* tool_path, char* data_path) {
 	sprintf(buf, "%s -V", tool_path); // tool_path is already quoted
 	HANDLE g_hChildStd_OUT_Rd = NULL;
 	HANDLE g_hChildStd_OUT_Wr = NULL;
+	DWORD nbByteRead;
 	SECURITY_ATTRIBUTES saAttr;
 	saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
 	saAttr.bInheritHandle = TRUE;
@@ -257,7 +258,7 @@ int check_version(char* tool_path, char* data_path) {
 		return 1;
 	CloseHandle(piProcInfo.hProcess);
 	CloseHandle(piProcInfo.hThread);
-	ReadFile(g_hChildStd_OUT_Rd, toolversion, 20, NULL, NULL);
+	ReadFile(g_hChildStd_OUT_Rd, toolversion, 20, &nbByteRead, NULL);
 #endif
     // strip whitespace
     for (size_t i=0, j=0; toolversion[j]=toolversion[i]; j+=!isspace(toolversion[i++]));

--- a/src/network/net_lowlevel.cpp
+++ b/src/network/net_lowlevel.cpp
@@ -242,7 +242,7 @@ std::string NetGetHostname()
 int NetSocketAddr(unsigned long *ips, int maxAddr)
 {
 	int idx = 0;
-	PIP_ADAPTER_ADDRESSES pAddresses = NULL;
+	PIP_ADAPTER_ADDRESSES pFirstAddresses, pAddresses = NULL;
 	ULONG outBufLen = 0;
 	GetAdaptersAddresses(AF_INET,
 						 GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER,
@@ -251,6 +251,7 @@ int NetSocketAddr(unsigned long *ips, int maxAddr)
 	if (GetAdaptersAddresses(AF_INET,
 							 GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER,
 							 NULL, pAddresses, &outBufLen) == NO_ERROR) {
+		pFirstAddresses = pAddresses;
 		for (pAddresses; pAddresses; pAddresses = pAddresses->Next) {
 			if (idx == maxAddr) break;
 			if (pAddresses->Flags & IP_ADAPTER_RECEIVE_ONLY) continue;
@@ -261,6 +262,7 @@ int NetSocketAddr(unsigned long *ips, int maxAddr)
 			ips[idx++] = ((struct sockaddr_in*)pAddresses->FirstUnicastAddress->Address.lpSockaddr)->sin_addr.s_addr;
 		}
 	}
+	free(pFirstAddresses);
 
 	return idx;
 }

--- a/src/network/net_lowlevel.cpp
+++ b/src/network/net_lowlevel.cpp
@@ -257,7 +257,7 @@ int NetSocketAddr(unsigned long *ips, int maxAddr)
 			if ((pAddresses->Flags & IP_ADAPTER_IPV4_ENABLED) == 0) continue;
 			if (pAddresses->IfType != IF_TYPE_ETHERNET_CSMACD && pAddresses->IfType != IF_TYPE_IEEE80211) continue;
 			if (pAddresses->OperStatus != IfOperStatusUp) continue;
-			if (strlen((char*)pAddresses->PhysicalAddress) == 0) continue;
+			if (pAddresses->PhysicalAddressLength == 0) continue;
 			ips[idx++] = ((struct sockaddr_in*)pAddresses->FirstUnicastAddress->Address.lpSockaddr)->sin_addr.s_addr;
 		}
 	}

--- a/src/ui/widgets.cpp
+++ b/src/ui/widgets.cpp
@@ -912,7 +912,8 @@ void MultiLineLabel::draw(gcn::Graphics *graphics)
 	}
 
 	for (int i = 0; i < (int)this->mTextRows.size(); ++i) {
-		graphics->drawText(this->mTextRows[i], textX, textY + i * this->getFont()->getHeight(),
+		if (this->mTextRows[i].length() != 0)
+			graphics->drawText(this->mTextRows[i], textX, textY + i * this->getFont()->getHeight(),
 						   this->getAlignment());
 	}
 }


### PR DESCRIPTION
In mission briefing (or possibly anywhere else), there is no need to render empty strings.