### PR TITLE
Minor fixes for macOS. Fix linker error with libSDL2main. Add .DS_Store to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build
 .clangd
 compile_commands.json
 pytorchenv
+**/.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1096,8 +1096,12 @@ if(WIN32 AND MINGW AND ENABLE_STATIC)
 	set_target_properties(stratagus PROPERTIES LINK_FLAGS "${LINK_FLAGS} -static-libgcc -static-libstdc++ -Wl,--stack,10485760")
 endif()
 
-if(APPLE OR WIN32)
+if(WIN32)
   set_target_properties(stratagus PROPERTIES LINK_FLAGS "${LINK_FLAGS} -lSDL2main")
+  set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS}")
+endif()
+if(APPLE)
+  set_target_properties(stratagus PROPERTIES LINK_FLAGS "${LINK_FLAGS} ${SDL2main_LIBRARY}")
   set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 


### PR DESCRIPTION
Building SDL2 from source on macOS doesn't produce a dynamic library for libSDL2main.  Similarly installing SDL2 through macports only installs libSDL2main.a.  The first commit solves the issue with linking to SDL2main. 

The second commit adds .DS_Store to .gitignore to avoid file pollution. 