### PR TITLE
Fix compiler detection and flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,10 +843,10 @@ endif()
 
 # Stratagus needs to have char by default signed
 # No idea how to tell this to other compilers
-if(CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -Werror")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
 endif()
-if(CMAKE_COMPILER_IS_GNUC)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")
 endif()
 if(WIN32 AND MSVC)


### PR DESCRIPTION
- Use `CMAKE_<LANG>_COMPILER_ID` to detect compiler as CMake docs suggest
- Support clang properly
- Don't set -Werror (see https://amdmi3.ru/posts/packaging-friendliness-compiler-flags-to-avoid/)