### PR TITLE
Fixed broken map rendering in cases when map is revealed

### DIFF
--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -280,8 +280,9 @@ void CViewport::DrawMapBackgroundInViewport() const
 		graphicTileOffset = Map.Tileset->getLogicalToGraphicalTileSizeMultiplier();
 		canShortcut = false;
 	} else {
-		canShortcut = FogOfWar->GetType() != FogOfWarTypes::cEnhanced && !ReplayRevealMap;
 		graphicTileOffset = 1;
+		canShortcut = (GameSettings.RevealMap == MapRevealModes::cHidden || FogOfWar->GetType() == FogOfWarTypes::cTiledLegacy)
+					  && !ReplayRevealMap; 
 	}
 
 	while (sy < 0) {


### PR DESCRIPTION
There are  few map reveal modes (known and explored) which works with tiled (not legacy) fog type too, so we have to check map reveal mode instead of fog type here.