### PR TITLE
Additional fix for broken map rendering in cases when map is revealed.

### DIFF
--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -282,6 +282,7 @@ void CViewport::DrawMapBackgroundInViewport() const
 	} else {
 		graphicTileOffset = 1;
 		canShortcut = (GameSettings.RevealMap == MapRevealModes::cHidden || FogOfWar->GetType() == FogOfWarTypes::cTiledLegacy)
+					  && FogOfWar->GetType() != FogOfWarTypes::cEnhanced
 					  && !ReplayRevealMap; 
 	}
 


### PR DESCRIPTION
After all, it turns out that you have to switch off this optimization for enhanced fog too.