### PR TITLE
video: font: fixed glyph last pointer calculation 

### DIFF
--- a/src/video/font.cpp
+++ b/src/video/font.cpp
@@ -874,17 +874,18 @@ void CFont::MeasureWidths()
 	CharWidth[0] = G->Width / 2;  // a reasonable value for SPACE
 	Uint32 ckey = 0;
 	const int ipr = G->Surface->w / G->Width; // images per row
+	const unsigned char* lsp = (const unsigned char *) G->Surface->pixels +
+		G->Surface->pitch * G->GraphicHeight; // last surface pointer + 1
 
 	SDL_LockSurface(G->Surface);
 	SDL_GetColorKey(G->Surface, &ckey);
 	for (int y = 1; y < maxy; ++y) {
 		const unsigned char *sp = (const unsigned char *)G->Surface->pixels +
 								  (y / ipr) * G->Surface->pitch * G->Height +
-								  (y % ipr) * G->Width - 1;
-		const unsigned char *gp = sp + G->Surface->pitch * G->Height;
+								  (y % ipr) * G->Width - 1; // start pointer of glyph
+		const unsigned char *gp = sp + G->Surface->pitch * (G->Height - 1) + G->Width; // last pointer of glyph + 1
 		// Bail out if no letters left
-		if (gp >= ((const unsigned char *)G->Surface->pixels +
-				   G->Surface->pitch * G->GraphicHeight)) {
+		if (gp >= lsp) {
 			break;
 		}
 		while (sp < gp) {


### PR DESCRIPTION
For some reason that I can't understand (I have no knowledge in graphic surfaces) this check fails for `large` font created by wargus's wartool from russian `SPK` Warcraft II version.

After applying fix for russian translation [1] I found that some letters are missing from words, however they are presented in translation strings.  
Debugging this issue I found that `CFont::CharWidth` have no data for those letters.

I added printf() here and the cycle was stopped at y=196, with gp less than 255, however all letters before 196 had gp=255.

After removing this check I got values:
```
CFont::MeasureWidths: large: y: 194: sp: 255, gp: 255
CFont::MeasureWidths: large: y: 195: sp: 0, gp: 0
CFont::MeasureWidths: large: y: 196: sp: 255, gp: 0
CFont::MeasureWidths: large: y: 197: sp: 255, gp: 125
CFont::MeasureWidths: large: y: 198: sp: 255, gp: 70
CFont::MeasureWidths: large: y: 199: sp: 255, gp: 38
CFont::MeasureWidths: large: y: 200: sp: 255, gp: 0
CFont::MeasureWidths: large: y: 201: sp: 255, gp: 85
CFont::MeasureWidths: large: y: 202: sp: 255, gp: 0
CFont::MeasureWidths: large: y: 203: sp: 255, gp: 0
CFont::MeasureWidths: large: y: 204: sp: 255, gp: 112
CFont::MeasureWidths: large: y: 205: sp: 255, gp: 0
CFont::MeasureWidths: large: y: 206: sp: 255, gp: 72
CFont::MeasureWidths: large: y: 207: sp: 255, gp: 0 
CFont::MeasureWidths: large: y: 208: sp: 255, gp: 0
CFont::MeasureWidths: large: y: 209: sp: 255, gp: 0
```

And `CFont::CharWidth` was populated for remaining letters so the game text now looks fine.

The `large` font is attached

[1] https://github.com/Wargus/wargus/pull/436

![large](https://user-images.githubusercontent.com/3389586/213882581-8e01a116-b287-42b3-9b1e-39004d376bd2.png)
