### PR TITLE
Silence warnings: Change a logical || to a bitwise |

### DIFF
--- a/src/include/unit_find.h
+++ b/src/include/unit_find.h
@@ -237,7 +237,7 @@ void SelectFixed(const Vec2i &ltPos, const Vec2i &rbPos, std::vector<CUnit *> &u
 	Assert(Map.Info.IsPointOnMap(rbPos));
 	Assert(units.empty());
 	units.reserve(selectMax << 1);
-	int max = selectMax || INT_MAX;
+	int max = selectMax | INT_MAX;
 
 	for (Vec2i posIt = ltPos; posIt.y != rbPos.y + 1; ++posIt.y) {
 		for (posIt.x = ltPos.x; posIt.x != rbPos.x + 1; ++posIt.x) {

--- a/src/include/unit_find.h
+++ b/src/include/unit_find.h
@@ -237,7 +237,7 @@ void SelectFixed(const Vec2i &ltPos, const Vec2i &rbPos, std::vector<CUnit *> &u
 	Assert(Map.Info.IsPointOnMap(rbPos));
 	Assert(units.empty());
 	units.reserve(selectMax << 1);
-	int max = selectMax | INT_MAX;
+	int max = selectMax ? selectMax : INT_MAX;
 
 	for (Vec2i posIt = ltPos; posIt.y != rbPos.y + 1; ++posIt.y) {
 		for (posIt.x = ltPos.x; posIt.x != rbPos.x + 1; ++posIt.x) {


### PR DESCRIPTION
Silences the following compiler warning. Was previously being called 33 times: 
```
warning: use of logical '||' with constant operand [-Wconstant-logical-operand]
        int max = selectMax || INT_MAX;
                            ^  ~~~~~~~
note: use '|' for a bitwise operation
```

Someone with better C++ skills than me should review to make sure functionality remains the same.