### PR TITLE
Requires Testing - [macOS] Use the Application Support folder for game data

### DIFF
--- a/gameheaders/stratagus-game-launcher.h
+++ b/gameheaders/stratagus-game-launcher.h
@@ -223,7 +223,7 @@ static void SetUserDataPath(char* data_path) {
 		if (dataDir) {
 			strcpy(data_path, dataDir);
 #ifdef USE_MAC
-			strcat(data_path, "/Library/Stratagus/");
+			strcat(data_path, "/Library/Application\ Support/Stratagus/");
 #else
 			strcat(data_path, "/.local/share/stratagus/");
 #endif

--- a/src/stratagus/parameters.cpp
+++ b/src/stratagus/parameters.cpp
@@ -79,7 +79,7 @@ void Parameters::SetDefaultUserDirectory(bool noPortable)
 		configDir = getenv("HOME");
 		if (configDir) {
 #ifdef USE_MAC
-			userDirectory = std::string(configDir) + "/Library/Stratagus";
+			userDirectory = std::string(configDir) + "/Library/Application\ Support/Stratagus";
 #else
 			userDirectory = std::string(configDir) + "/.config/stratagus";
 #endif // USE_MAC


### PR DESCRIPTION
Stratagus currently puts data files in `~/Library/Stratagus`, but it should use `~/Library/Application\ Support/Stratagus`

I have tested this using my previously installed game data. After building with these changes, I moved the Stratagus folder into Application Support and was able to launch Wargus through the command line as usual. 

I have not tested with Wartools to see if it extracts data correctly. That will need to be tested before merging. 