### PR TITLE
[WIP] Add `DebugPrint` for not found resource by ident.

### DIFF
--- a/src/animation/animation.cpp
+++ b/src/animation/animation.cpp
@@ -381,6 +381,7 @@ CAnimations *AnimationsByIdent(std::string_view ident)
 	if (it != AnimationMap.end()) {
 		return it->second;
 	}
+	DebugPrint("Unknown animation '%s'\n" _C_ ident.data());
 	return nullptr;
 }
 

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -124,6 +124,7 @@ MissileType *MissileTypeByIdent(std::string_view ident)
 	if (it != MissileTypes.end()) {
 		return it->second;
 	}
+	DebugPrint("Unknown missileType '%s'\n" _C_ ident.data());
 	return nullptr;
 }
 

--- a/src/spell/spells.cpp
+++ b/src/spell/spells.cpp
@@ -420,6 +420,7 @@ SpellType *SpellTypeByIdent(const std::string_view &ident)
 	if (it != SpellTypeTable.end()) {
 		return *it;
 	}
+	DebugPrint("Unknown spellType '%s'\n" _C_ ident.data());
 	return nullptr;
 }
 

--- a/src/stratagus/construct.cpp
+++ b/src/stratagus/construct.cpp
@@ -157,13 +157,14 @@ void CleanConstructions()
 **
 **  @return       Construction structure pointer
 */
-CConstruction *ConstructionByIdent(std::string_view name)
+CConstruction *ConstructionByIdent(std::string_view ident)
 {
 	for (CConstruction *c : Constructions) {
-		if (c->Ident == name) {
+		if (c->Ident == ident) {
 			return c;
 		}
 	}
+	DebugPrint("Unknown construction '%s'\n" _C_ ident.data());
 	return nullptr;
 }
 

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -193,6 +193,7 @@ CPopup *PopupByIdent(const std::string &ident)
 	if (it != UI.ButtonPopups.end()) {
 		return *it;
 	}
+	DebugPrint("Unknown popup '%s'\n" _C_ ident.data());
 	return nullptr;
 }
 

--- a/src/unit/unittype.cpp
+++ b/src/unit/unittype.cpp
@@ -849,6 +849,7 @@ CUnitType *UnitTypeByIdent(std::string_view ident)
 	if (ret != UnitTypeMap.end()) {
 		return (*ret).second;
 	}
+	DebugPrint("Unknown unitType '%s'\n" _C_ ident.data());
 	return nullptr;
 }
 

--- a/src/unit/upgrade.cpp
+++ b/src/unit/upgrade.cpp
@@ -462,7 +462,6 @@ int UnitTypeIdByIdent(std::string_view ident)
 	if (type) {
 		return type->Slot;
 	}
-	DebugPrint(" fix this %s\n" _C_ ident.data());
 	return -1;
 }
 


### PR DESCRIPTION
So don't forget `-p` command line argument to see typos with identifiers.