### PR TITLE
quick fix for a define on Linux

### DIFF
--- a/src/include/unittype.h
+++ b/src/include/unittype.h
@@ -58,6 +58,9 @@
 #include <algorithm>
 #include <map>
 
+// Fix problems with defined None in X.h included though SDL.h
+#undef None
+
 /*----------------------------------------------------------------------------
 --  Declarations
 ----------------------------------------------------------------------------*/


### PR DESCRIPTION
quick fix for:
In file included from /usr/include/X11/Xlib.h:44,
                 from /usr/include/SDL2/SDL_syswm.h:69,
                 from /home/andreas/src/git/stratagus/stratagus/src/video/sdl.cpp:58:
/home/andreas/src/git/stratagus/stratagus/src/include/unittype.h:510:9: error: expected identifier before numeric constant
  510 |         None = 0, /// Nothing
      |         ^~~~
/home/andreas/src/git/stratagus/stratagus/src/include/unittype.h:510:9: error: expected ‘}’ before numeric constant
In file included from /home/andreas/src/git/stratagus/stratagus/src/include/unit.h:43,
                 from /home/andreas/src/git/stratagus/stratagus/src/video/sdl.cpp:79:
/home/andreas/src/git/stratagus/stratagus/src/include/unittype.h:509:1: note: to match this ‘{’
  509 | {
      | ^
In file included from /usr/include/X11/Xlib.h:44,
                 from /usr/include/SDL2/SDL_syswm.h:69,
                 from /home/andreas/src/git/stratagus/stratagus/src/video/sdl.cpp:58:
/home/andreas/src/git/stratagus/stratagus/src/include/unittype.h:510:9: error: expected unqualified-id before numeric constant
  510 |         None = 0, /// Nothing
  .... more stuff with None = 0...

Maybe there's a better solution, but it fixed the problem