### PR TITLE
Mng fixes

### DIFF
--- a/src/video/mng.cpp
+++ b/src/video/mng.cpp
@@ -226,11 +226,10 @@ static std::map<std::string, Mng *> MngCache;
 Mng *Mng::New(const std::string &name)
 {
 	const std::string file = LibraryFileName(name);
-	Mng *mng = MngCache[file];
+	Mng *&mng = MngCache[file];
 	if (mng == nullptr) {
 		mng = new Mng();
 		mng->name = LibraryFileName(name);
-		Assert(mng);
 	}
 	mng->refcnt++;
 	return mng;


### PR DESCRIPTION
- Fix mng cache.
- `new` doesn't return `nullptr` (but throw), so `Assert` is useless (was misplaced anyway).