### PR TITLE
Fix typo/regressions:

### DIFF
--- a/src/ai/script_ai.cpp
+++ b/src/ai/script_ai.cpp
@@ -1612,7 +1612,7 @@ static int CclDefineAiPlayer(lua_State *l)
 	// FIXME: lose this:
 	// Assert(!Players[playerIdx].Ai && Players[playerIdx].AiEnabled);
 
-	Players[playerIdx].Ai = std::unique_ptr<PlayerAi>();
+	Players[playerIdx].Ai = std::make_unique<PlayerAi>();
 	PlayerAi &ai = *Players[playerIdx].Ai;
 	ai.Player = &Players[playerIdx];
 

--- a/src/stratagus/iolib.cpp
+++ b/src/stratagus/iolib.cpp
@@ -173,6 +173,7 @@ int CFile::printf(const char *format, ...)
 		va_end(ap);
 		// If that worked, string was processed.
 		if (n > -1 && n < p.size()) {
+			p.resize(n);
 			break;
 		}
 		// Else try again with more space.


### PR DESCRIPTION
- `std::make_unique<T>()` != `std::unique_ptr<T>()`.
- `CFile::printf` now longer print extra nul characters.