### PR TITLE
Separate highlights of AStar passability from the enable map grid option.

### DIFF
--- a/src/include/viewport.h
+++ b/src/include/viewport.h
@@ -112,11 +112,20 @@ public:
 		return CViewport::ShowGrid;
 	}
 
-	static void EnableGrid(const bool value)
+	static void EnableGrid(bool value)
 	{
 		CViewport::ShowGrid = value;
 	}
 
+	static bool isPassabilityHighlighted()
+	{
+		return CViewport::ShowAStarPassability;
+	}
+
+	static void HighlightPassability(bool value)
+	{
+		CViewport::ShowAStarPassability = value;
+	}
 
 	PixelSize GetPixelSize() const;
 	const PixelPos &GetTopLeftPos() const { return TopLeftPos;}
@@ -155,10 +164,10 @@ public:
 	CUnit *Unit;              /// Bound to this unit
 private:
 	SDL_Surface *FogSurface { nullptr }; /// Texture for fog of war. Viewport sized.
+
 	static bool ShowGrid;
-
+	static bool ShowAStarPassability;
 };
-
 
 //@}
 

--- a/src/map/map_draw.cpp
+++ b/src/map/map_draw.cpp
@@ -45,10 +45,12 @@
 #include "unittype.h"
 #include "ui.h"
 #include "video.h"
+#include "editor.h"
 
 #include <cstdlib>
 
 bool CViewport::ShowGrid = false;
+bool CViewport::ShowAStarPassability = false;
 
 
 CViewport::CViewport() : MapWidth(0), MapHeight(0), Unit(nullptr)
@@ -329,7 +331,7 @@ void CViewport::DrawMapBackgroundInViewport(const fieldHighlightChecker highligh
 			Map.TileGraphic->DrawFrameClip(tile, dx, dy);
 #ifdef DEBUG
 			// AStar passability overlay
-			if (CViewport::isGridEnabled()) {
+			if (CViewport::isPassabilityHighlighted() && Editor.Running == EditorNotRunning) {
 				for (int i = 0; i < graphicTileOffset; i++) {
 					for (int j = 0; j < graphicTileOffset; j++) {
 						if (Map.Fields[sx + j + (mapW * i)].getFlag() & MapFieldUnpassable) {
@@ -347,7 +349,7 @@ void CViewport::DrawMapBackgroundInViewport(const fieldHighlightChecker highligh
 #endif
 			/// Highlight layer if needed (editor stuff)
 			if (highlightChecker && highlightChecker(mf)) {
-				Video.FillTransRectangleClip(ColorRed, dx, dy, PixelTileSize.x, PixelTileSize.y, 128);
+				Video.FillTransRectangleClip(ColorRed, dx, dy, PixelTileSize.x, PixelTileSize.y, 64);
 			}
 			if constexpr(graphicalTileIsLogicalTile) {
 				++sx;
@@ -363,11 +365,9 @@ void CViewport::DrawMapBackgroundInViewport(const fieldHighlightChecker highligh
 		}
 		dy += graphicTileSize.y;
 	}
-#ifdef DEBUG
 	if (CViewport::isGridEnabled()) {
 		DrawMapGridInViewport();
 	}
-#endif
 }
 
 /**

--- a/src/map/script_map.cpp
+++ b/src/map/script_map.cpp
@@ -304,7 +304,7 @@ static int CclSetMinimapTerrain(lua_State *l)
 **
 **  @param l  Lua state.
 **
-**  @return   0 for success, 1 for wrong type;
+**  @return   0 for success
 */
 static int CclSetEnableMapGrid(lua_State *l)
 {
@@ -320,6 +320,30 @@ static int CclGetIsMapGridEnabled(lua_State *l)
 {
 	LuaCheckArgs(l, 0);
 	lua_pushboolean(l, CViewport::isGridEnabled());
+	return 1;
+}
+
+/**
+**  Highlight tiles passability  (true|false)
+**
+**  @param l  Lua state.
+**
+**  @return   0 for success
+*/
+static int CclSetHighlightPassability(lua_State *l)
+{
+	LuaCheckArgs(l, 1);
+	CViewport::HighlightPassability(LuaToBoolean(l, 1));
+	return 0;
+}
+
+/**
+**  Check if tiles passability higlighted
+*/
+static int CclGetIsPassabilityHighlighted(lua_State *l)
+{
+	LuaCheckArgs(l, 0);
+	lua_pushboolean(l, CViewport::isPassabilityHighlighted());
 	return 1;
 }
 
@@ -1140,6 +1164,9 @@ void MapCclRegister()
 
 	lua_register(Lua, "SetEnableMapGrid", CclSetEnableMapGrid);
 	lua_register(Lua, "GetIsMapGridEnabled", CclGetIsMapGridEnabled);
+
+	lua_register(Lua, "SetHighlightPassability", CclSetHighlightPassability);
+	lua_register(Lua, "GetIsPassabilityHighlighted", CclGetIsPassabilityHighlighted);
 
 	lua_register(Lua, "SetFieldOfViewType", CclSetFieldOfViewType);
 	lua_register(Lua, "GetFieldOfViewType", CclGetFieldOfViewType);


### PR DESCRIPTION
The option is used for debugging purposes and was activated together with enabling the map grid. It was a bit annoying. 
This separates them into two independent options.

Now can be toggled with `SetHighlightPassability(true/false)` from lua (incl. `eval` chit code)