### PR TITLE
Build libs as static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1104,7 +1104,7 @@ add_custom_command(OUTPUT tolua.cpp
 	VERBATIM
 )
 
-add_library(stratagus_lib ${stratagus_SRCS} ${stratagus_HDRS})
+add_library(stratagus_lib STATIC ${stratagus_SRCS} ${stratagus_HDRS})
 if (ENABLE_STDIO_REDIRECT)
 	add_executable(stratagus WIN32 src/stratagus/main.cpp)
 else ()


### PR DESCRIPTION
Otherwise it falls back to the global BUILD_SHARED_LIBS that might be set to ON. In that case stratagus_lib.so or stratagus_lib.dll are built.

Makes it consistent to all other libs (from third-party).

submodule third-party containing PR https://github.com/Wargus/dependencies/pull/2 should also be included.
