### PR TITLE
Initialize CUnit::JustMoved in CUnit::Init()

### DIFF
--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -451,6 +451,7 @@ void CUnit::Init()
 	Waiting = 0;
 	MineLow = 0;
 	ZDisplaced = 0;
+	JustMoved = 0;
 	TeamSelected = 0;
 	RescuedFrom = nullptr;
 	memset(VisCount, 0, sizeof(VisCount));


### PR DESCRIPTION
Reported by valgrind:
```
==3108== Conditional jump or move depends on uninitialised value(s)
==3108==    at 0x1EC37A: COrder_Still::Execute(CUnit&) (action_still.cpp:424)
==3108==    by 0x1EF361: HandleUnitAction (actions.cpp:449)
==3108==    by 0x1EF361: UnitActionsEachCycle (actions.cpp:574)
==3108==    by 0x1EF361: UnitActions() (actions.cpp:623)
==3108==    by 0x295B9C: GameLogicLoop (mainloop.cpp:268)
==3108==    by 0x295B9C: SingleGameLoop (mainloop.cpp:377)
==3108==    by 0x295B9C: GameMainLoop() (mainloop.cpp:413)
==3108==    by 0x21798F: StartMap(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (game.cpp:146)
==3108==    by 0x302F90: tolua_stratagus_StartMap00(lua_State*) (tolua.cpp:1107)
==3108==    by 0x48A9F4D: luaD_precall (ldo.c:320)
==3108==    by 0x48BBBB3: luaV_execute (lvm.c:591)
==3108==    by 0x48AA5FC: luaD_call (ldo.c:378)
==3108==    by 0x48A98EA: luaD_rawrunprotected (ldo.c:116)
==3108==    by 0x48AA79C: luaD_pcall (ldo.c:464)
==3108==    by 0x48A1E67: lua_pcall (lapi.c:821)
==3108==    by 0x29D90E: LuaCall(lua_State*, int, int, int, bool) (script.cpp:200)
==3108==  Uninitialised value was created by a heap allocation
==3108==    at 0x483EEDD: operator new(unsigned long) (vg_replace_malloc.c:485)
==3108==    by 0x1A7FA5: CUnitManager::AllocUnit() (unit_manager.cpp:90)
==3108==    by 0x19CA7E: MakeUnit(CUnitType const&, CPlayer*) (unit.cpp:746)
==3108==    by 0x2CD968: CclCreateUnit(lua_State*) (script_unit.cpp:784)
==3108==    by 0x48A9F4D: luaD_precall (ldo.c:320)
==3108==    by 0x48BBB48: luaV_execute (lvm.c:612)
==3108==    by 0x48AA5FC: luaD_call (ldo.c:378)
==3108==    by 0x48A98EA: luaD_rawrunprotected (ldo.c:116)
==3108==    by 0x48AA79C: luaD_pcall (ldo.c:464)
==3108==    by 0x48A1E67: lua_pcall (lapi.c:821)
==3108==    by 0x29D90E: LuaCall(lua_State*, int, int, int, bool) (script.cpp:200)
==3108==    by 0x2A25D0: LuaLoadFile(std::filesystem::__cxx11::path const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (script.cpp:271)
```