### PR TITLE
Pathfinder: Fix out-of-bounds read/write at load/store of games

### DIFF
--- a/src/include/pathfinder.h
+++ b/src/include/pathfinder.h
@@ -83,7 +83,7 @@ public:
 	void SetMinRange(int range);
 	void SetMaxRange(int range);
 
-	void PathRacalculated();
+	void PathRecalculated();
 
 	void Save(CFile &file) const;
 	void Load(lua_State *l);

--- a/src/pathfinder/pathfinder.cpp
+++ b/src/pathfinder/pathfinder.cpp
@@ -368,7 +368,7 @@ void PathFinderInput::SetMaxRange(int range)
 	}
 }
 
-void PathFinderInput::PathRacalculated()
+void PathFinderInput::PathRecalculated()
 {
 	unitSize.x = unit->Type->TileWidth;
 	unitSize.y = unit->Type->TileHeight;
@@ -405,7 +405,7 @@ static int NewPath(PathFinderInput &input, PathFinderOutput &output)
 						  input.GetMinRange(), input.GetMaxRange(),
 						  path, PathFinderOutput::MAX_PATH_LENGTH,
 						  *input.GetUnit());
-	input.PathRacalculated();
+	input.PathRecalculated();
 	if (i == PF_FAILED) {
 		i = PF_UNREACHABLE;
 	}

--- a/src/pathfinder/pathfinder.cpp
+++ b/src/pathfinder/pathfinder.cpp
@@ -413,10 +413,15 @@ static int NewPath(PathFinderInput &input, PathFinderOutput &output)
 	// Update path if it was requested. Otherwise we may only want
 	// to know if there exists a path.
 	if (path != nullptr) {
-		output.Length = std::min<int>(i, PathFinderOutput::MAX_PATH_LENGTH);
-		output.OverflowLength = std::min<int>(i - output.Length, PathFinderOutput::MAX_OVERFLOW);
-		if (output.Length == 0) {
-			++output.Length;
+		if (i >= 0) {
+			output.Length = std::min<int>(i, PathFinderOutput::MAX_PATH_LENGTH);
+			output.OverflowLength = std::min<int>(i - output.Length, PathFinderOutput::MAX_OVERFLOW);
+			if (output.Length == 0) {
+				++output.Length;
+			}
+		} else {
+			output.Length = 0;
+			output.OverflowLength = 0;
 		}
 	}
 	return i;

--- a/src/unit/script_unit.cpp
+++ b/src/unit/script_unit.cpp
@@ -257,10 +257,13 @@ void PathFinderOutput::Load(lua_State *l)
 				LuaError(l, "incorrect argument _");
 			}
 			const int subargs = lua_rawlen(l, -1);
-			for (int k = 0; k < subargs; ++k) {
-				this->Path[k] = LuaToNumber(l, -1, k + 1);
+			if (subargs <= PathFinderOutput::MAX_PATH_LENGTH)
+			{
+				for (int k = 0; k < subargs; ++k) {
+					this->Path[k] = LuaToNumber(l, -1, k + 1);
+				}
+				this->Length = subargs;
 			}
-			this->Length = subargs;
 			lua_pop(l, 1);
 		} else {
 			LuaError(l, "PathFinderOutput::Load: Unsupported tag: %s", tag.data());

--- a/src/unit/unit_save.cpp
+++ b/src/unit/unit_save.cpp
@@ -101,7 +101,7 @@ void PathFinderOutput::Save(CFile &file) const
 	if (this->OverflowLength) {
 		file.printf("\"overflow-length\", %d, ", this->OverflowLength);
 	}
-	if (this->Length > 0) {
+	if (this->Length > 0 && this->Length <= PathFinderOutput::MAX_PATH_LENGTH) {
 		file.printf("\"path\", {");
 		for (int i = 0; i < this->Length; ++i) {
 			file.printf("%d, ", this->Path[i]);


### PR DESCRIPTION
Fix memory issues at save and load.
Saving a too long path stores no path at all (=an empty path). Loading a too long path also sets it to empty (to be compatible to old saved files).
I hope this is good.

It also fixes the value of Length at runtime.

Resolves https://github.com/Wargus/stratagus/issues/610
It might resolve some of the open crash-issues.