### PR TITLE
Fix some load/save issues with Triggers

### DIFF
--- a/src/game/trigger.cpp
+++ b/src/game/trigger.cpp
@@ -614,8 +614,6 @@ void SaveTriggers(CFile &file)
 	}
 
 	file.printf("\n");
-	file.printf("if (Triggers ~= nil) then assert(loadstring(Triggers))() end\n");
-	file.printf("\n");
 }
 
 /**

--- a/src/game/trigger.cpp
+++ b/src/game/trigger.cpp
@@ -428,7 +428,7 @@ static int CclAddTrigger(lua_State *l)
 	}
 
 	const int i = lua_rawlen(l, -1);
-	if (!ActiveTriggers.empty() && !ActiveTriggers[i / 2]) {
+	if (i / 2 < ActiveTriggers.size() && !ActiveTriggers[i / 2]) {
 		lua_pushnil(l);
 		lua_rawseti(l, -2, i + 1);
 		lua_pushnil(l);

--- a/src/game/trigger.cpp
+++ b/src/game/trigger.cpp
@@ -394,14 +394,16 @@ void ActionStopTimer()
 /**
 **  Remove a trigger
 **
-**  @param trig  Current trigger
+**  @param l     Lua state, top of stack is trigger table
+**
+**  @param trig  Index of trigger to be removed
 */
-static void TriggerRemoveTrigger(int trig)
+static void TriggerRemoveTrigger(lua_State *l, int trig)
 {
-	lua_pushnumber(Lua, -1);
-	lua_rawseti(Lua, -2, trig + 1);
-	lua_pushnumber(Lua, -1);
-	lua_rawseti(Lua, -2, trig + 2);
+	lua_pushnumber(l, -1);
+	lua_rawseti(l, -2, trig + 1);
+	lua_pushnumber(l, -1);
+	lua_rawseti(l, -2, trig + 2);
 }
 
 /**
@@ -474,7 +476,7 @@ static int CclSetActiveTriggers(lua_State *l)
 {
 	const int args = lua_gettop(l);
 
-	lua_getglobal(Lua, "_triggers_");
+	lua_getglobal(l, "_triggers_");
 	const int triggerCount = lua_rawlen(l, -1) / 2;
 
 	ActiveTriggers.resize(args);
@@ -482,11 +484,11 @@ static int CclSetActiveTriggers(lua_State *l)
 		ActiveTriggers[j] = LuaToBoolean(l, j + 1);
 		if (j < triggerCount && !ActiveTriggers[j])
 		{
-			TriggerRemoveTrigger(j * 2);
+			TriggerRemoveTrigger(l, j * 2);
 		}
 	}
 
-	lua_pop(Lua, 1);
+	lua_pop(l, 1);
 
 	return 0;
 }
@@ -553,7 +555,7 @@ void TriggersEachCycle()
 		if (lua_gettop(Lua) > base + 1 && lua_toboolean(Lua, -1)) {
 			lua_settop(Lua, base + 1);
 			if (TriggerExecuteAction(currentTrigger + 1)) {
-				TriggerRemoveTrigger(currentTrigger);
+				TriggerRemoveTrigger(Lua, currentTrigger);
 			}
 		}
 		lua_settop(Lua, base + 1);

--- a/src/game/trigger.cpp
+++ b/src/game/trigger.cpp
@@ -392,6 +392,19 @@ void ActionStopTimer()
 }
 
 /**
+**  Remove a trigger
+**
+**  @param trig  Current trigger
+*/
+static void TriggerRemoveTrigger(int trig)
+{
+	lua_pushnumber(Lua, -1);
+	lua_rawseti(Lua, -2, trig + 1);
+	lua_pushnumber(Lua, -1);
+	lua_rawseti(Lua, -2, trig + 2);
+}
+
+/**
 ** <b>Description</b>
 **
 **  Add a trigger. A trigger is a set of two functions. The first is run every
@@ -492,19 +505,6 @@ static bool TriggerExecuteAction(int script)
 
 	// If action returns false remove it
 	return !ret;
-}
-
-/**
-**  Remove a trigger
-**
-**  @param trig  Current trigger
-*/
-static void TriggerRemoveTrigger(int trig)
-{
-	lua_pushnumber(Lua, -1);
-	lua_rawseti(Lua, -2, trig + 1);
-	lua_pushnumber(Lua, -1);
-	lua_rawseti(Lua, -2, trig + 2);
 }
 
 /**

--- a/src/game/trigger.cpp
+++ b/src/game/trigger.cpp
@@ -444,9 +444,9 @@ static int CclAddTrigger(lua_State *l)
 
 	const int i = lua_rawlen(l, -1);
 	if (i / 2 < ActiveTriggers.size() && !ActiveTriggers[i / 2]) {
-		lua_pushnil(l);
+		lua_pushnumber(l, -1);
 		lua_rawseti(l, -2, i + 1);
-		lua_pushnil(l);
+		lua_pushnumber(l, -1);
 		lua_rawseti(l, -2, i + 2);
 	} else {
 		lua_pushvalue(l, 1);
@@ -596,7 +596,7 @@ void SaveTriggers(CFile &file)
 		if (i) {
 			file.printf(", ");
 		}
-		if (!lua_isnil(Lua, -1)) {
+		if (!lua_isnumber(Lua, -1)) {
 			file.printf("true");
 		} else {
 			file.printf("false");

--- a/src/game/trigger.cpp
+++ b/src/game/trigger.cpp
@@ -474,10 +474,20 @@ static int CclSetActiveTriggers(lua_State *l)
 {
 	const int args = lua_gettop(l);
 
+	lua_getglobal(Lua, "_triggers_");
+	const int triggerCount = lua_rawlen(l, -1) / 2;
+
 	ActiveTriggers.resize(args);
 	for (int j = 0; j < args; ++j) {
 		ActiveTriggers[j] = LuaToBoolean(l, j + 1);
+		if (j < triggerCount && !ActiveTriggers[j])
+		{
+			TriggerRemoveTrigger(j * 2);
+		}
 	}
+
+	lua_pop(Lua, 1);
+
 	return 0;
 }
 


### PR DESCRIPTION
Fix some load/save issues with triggers
Fixes:
* Load will create the original number of triggers (not doubled)
* Load: No bad memory access checking for removed triggers
* Load: removed triggers are now really removed
* Save: The removed-status is correctly saved even if it was from loading a file
