### PR TITLE
Make unittests more robust

### DIFF
--- a/tests/stratagus/test_depend.cpp
+++ b/tests/stratagus/test_depend.cpp
@@ -344,6 +344,7 @@ TEST_CASE("upgrade depends")
 
 TEST_CASE("spell button depend")
 {
+	InitLua_Depend(R"()");
 	const auto requirements = std::string(_("Requirements:\n"));
 	CPlayer player{};
 	ButtonAction button;

--- a/tests/stratagus/test_depend.cpp
+++ b/tests/stratagus/test_depend.cpp
@@ -202,6 +202,7 @@ TEST_CASE("Unit depends")
 
 
 	CleanDependencies();
+	CleanUnitTypes();
 }
 
 TEST_CASE("upgrade depends")
@@ -340,6 +341,7 @@ TEST_CASE("upgrade depends")
 	}
 
 	CleanDependencies();
+	CleanUnitTypes();
 }
 
 TEST_CASE("spell button depend")
@@ -358,4 +360,5 @@ TEST_CASE("spell button depend")
 	CHECK(PrintDependencies(player, button) == requirements + "-upgradeMain\n");
 
 	Selected.clear();
+	CleanUnitTypes();
 }

--- a/tests/stratagus/test_depend.cpp
+++ b/tests/stratagus/test_depend.cpp
@@ -360,5 +360,6 @@ TEST_CASE("spell button depend")
 	CHECK(PrintDependencies(player, button) == requirements + "-upgradeMain\n");
 
 	Selected.clear();
+	CleanDependencies();
 	CleanUnitTypes();
 }

--- a/tests/stratagus/test_trigger.cpp
+++ b/tests/stratagus/test_trigger.cpp
@@ -31,6 +31,8 @@
 
 #include "stratagus.h"
 
+#include "interface.h"
+#include "results.h"
 #include "trigger.h"
 #include "script.h"
 
@@ -38,6 +40,9 @@ namespace
 {
 [[nodiscard]] auto InitLuaTrigger(std::string content)
 {
+	GameRunning = true;
+	GamePaused = false;
+	GameResult = GameNoResult;
 	InitLua();
 	CHECK(Lua);
 	CleanTriggers();
@@ -64,6 +69,9 @@ namespace
 				lua_close(Lua);
 				Lua = nullptr;
 			}
+			GameRunning = true;
+			GamePaused = false;
+			GameResult = GameNoResult;
 		}
 	};
 	return S(); // copy-elision
@@ -166,4 +174,7 @@ TEST_CASE("Trigger Pause")
 	TriggersEachCycle();
 	// do not run check C3
 	CHECK(test_getLuaGlobalStr("log") == "C1 C2 A2 ");
+	CHECK_FALSE(GameRunning);
+	CHECK(GamePaused);
+	CHECK(GameResult == GameVictory);
 }

--- a/tests/stratagus/test_trigger.cpp
+++ b/tests/stratagus/test_trigger.cpp
@@ -178,3 +178,42 @@ TEST_CASE("Trigger Pause")
 	CHECK(GamePaused);
 	CHECK(GameResult == GameVictory);
 }
+
+TEST_CASE("Trigger ActionVictory")
+{
+	const auto raii = InitLuaTrigger(R"(
+		AddTrigger(function() return true end, function() return ActionVictory() end)
+	)");
+
+	REQUIRE_FALSE(GamePaused);
+	TriggersEachCycle();
+	CHECK_FALSE(GameRunning);
+	CHECK(GamePaused);
+	CHECK(GameResult == GameVictory);
+}
+
+TEST_CASE("Trigger ActionVictory")
+{
+	const auto raii = InitLuaTrigger(R"(
+		AddTrigger(function() return true end, function() return ActionDefeat() end)
+	)");
+
+	REQUIRE_FALSE(GamePaused);
+	TriggersEachCycle();
+	CHECK_FALSE(GameRunning);
+	CHECK(GamePaused);
+	CHECK(GameResult == GameDefeat);
+}
+
+TEST_CASE("Trigger ActionDraw")
+{
+	const auto raii = InitLuaTrigger(R"(
+		AddTrigger(function() return true end, function() return ActionDraw() end)
+	)");
+
+	REQUIRE_FALSE(GamePaused);
+	TriggersEachCycle();
+	CHECK_FALSE(GameRunning);
+	CHECK(GamePaused);
+	CHECK(GameResult == GameDraw);
+}


### PR DESCRIPTION
Depend: Fix test error with randomized order (unittype not existing).
Depend: Fix memory leaks.
Trigger: Fix Let tests work with randomized order (GamePaused is not initialized to false).
Trigger: Add more tests of Actions.

