### PR TITLE
Fix crash in `DisconnectedState::doOneStep` (`ctx.disconnect()` delet…

### DIFF
--- a/src/network/online_service.cpp
+++ b/src/network/online_service.cpp
@@ -1562,8 +1562,8 @@ public:
 	void doOneStep(Context &ctx) override
 	{
 		std::cout << message << std::endl;
-		ctx.disconnect();
 		ctx.showError(message);
+		ctx.disconnect();
 	}
 
 private:


### PR DESCRIPTION
…es `this`).