### PR TITLE
Fix glitch of burning building animation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ set(stratagus_tests_SRCS
 	tests/main.cpp
 	tests/stratagus/test_depend.cpp
 	tests/stratagus/test_luacallback.cpp
+	tests/stratagus/test_missile_fire.cpp
 	tests/stratagus/test_trigger.cpp
 	tests/stratagus/test_util.cpp
 	tests/network/test_net_lowlevel.cpp

--- a/src/include/missile.h
+++ b/src/include/missile.h
@@ -630,6 +630,8 @@ extern void InitMissiles();
 /// Clean missiles
 extern void CleanMissiles();
 
+extern bool is_BurningBuildingFramesSorted();
+
 extern void FreeBurningBuildingFrames();
 
 //@}

--- a/src/include/missile.h
+++ b/src/include/missile.h
@@ -630,7 +630,7 @@ extern void InitMissiles();
 /// Clean missiles
 extern void CleanMissiles();
 
-extern bool is_BurningBuildingFramesSorted();
+extern bool IsBurningBuildingFramesValid();
 
 extern void FreeBurningBuildingFrames();
 

--- a/src/include/missile.h
+++ b/src/include/missile.h
@@ -579,7 +579,7 @@ public:
 --  Variables
 ----------------------------------------------------------------------------*/
 
-extern std::vector<std::unique_ptr<BurningBuildingFrame>> BurningBuildingFrames;  /// Burning building frames
+extern std::vector<BurningBuildingFrame> BurningBuildingFrames;  /// Burning building frames
 
 /*----------------------------------------------------------------------------
 --  Functions

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -276,10 +276,37 @@ namespace ranges
 		return std::min_element(std::begin(range), std::end(range), cmp);
 	}
 
+	template <typename I, typename S, typename Pred, typename Proj = identity>
+	auto partition_point(I first, S last, Pred pred, Proj &&proj = {})
+	{
+		return std::partition_point(first, last,
+			[&](const auto &elem) {
+				return std::invoke(pred, std::invoke(proj, elem));
+			});
+	}
+
+	template <typename I, typename S, typename Value, typename Comparer = std::less<>, typename Proj = identity>
+	auto lower_bound(I first, S last, const Value &value, Comparer &&comparer = {}, Proj &&proj = {})
+	{
+		return std::lower_bound(first, last, value,
+			[&](const auto &lhs, const auto &rhs) {
+				return std::invoke(comparer, std::invoke(proj, lhs), rhs);
+			});
+	}
+
 	template <typename Range, typename Value>
 	auto lower_bound(Range &range, const Value &value)
 	{
 		return std::lower_bound(std::begin(range), std::end(range), value);
+	}
+
+	template <typename I, typename S, typename Value, typename Comparer = std::less<>, typename Proj = identity>
+	auto upper_bound(I first, S last, const Value &value, Comparer &&comparer = {}, Proj &&proj = {})
+	{
+		return std::upper_bound(first, last, value,
+			[&](const auto &lhs, const auto &rhs) {
+				return std::invoke(comparer, lhs, std::invoke(proj, rhs));
+			});
 	}
 
 	template <typename Range, typename Value, typename Comparer = std::less<>>

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -323,6 +323,12 @@ namespace ranges
 		std::sort(std::begin(range), std::end(range), std::forward<Comparer>(comparer));
 	}
 
+	template <typename Range, typename Comparer = std::less<>>
+	bool is_sorted(Range &range, Comparer &&comparer = {})
+	{
+		return std::is_sorted(std::begin(range), std::end(range), std::forward<Comparer>(comparer));
+	}
+
 }
 
 //@}

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -323,10 +323,13 @@ namespace ranges
 		std::sort(std::begin(range), std::end(range), std::forward<Comparer>(comparer));
 	}
 
-	template <typename Range, typename Comparer = std::less<>>
-	bool is_sorted(Range &range, Comparer &&comparer = {})
+	template <typename Range, typename Comparer = std::less<>, typename Proj = identity>
+	bool is_sorted(const Range &range, Comparer &&comparer = {}, Proj &&proj = {})
 	{
-		return std::is_sorted(std::begin(range), std::end(range), std::forward<Comparer>(comparer));
+		return std::is_sorted(std::begin(range), std::end(range),
+			[&](const auto &lhs, const auto &rhs) {
+				return std::invoke(comparer, std::invoke(proj, lhs), std::invoke(proj, rhs));
+			});
 	}
 
 }

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1298,17 +1298,24 @@ void CleanMissiles()
 }
 
 template <typename Range>
-bool is_PercentSortedDecreasing(const Range &range)
+bool IsPercentDecreasingValid(const Range &range)
 {
-	return ranges::is_sorted(
+	bool ret = true;
+	if (!range.empty())
+	{
+		ret = range.front().Percent <= 100
+			&& range.back().Percent >= 0;
+	}
+
+	return ret && ranges::is_sorted(
 		range,
 		std::greater(),
 		[](const auto& e) { return e.Percent; });
 }
 
-bool is_BurningBuildingFramesSorted()
+bool IsBurningBuildingFramesValid()
 {
-	return is_PercentSortedDecreasing(BurningBuildingFrames);
+	return IsPercentDecreasingValid(BurningBuildingFrames);
 }
 
 void FreeBurningBuildingFrames()

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -70,7 +70,7 @@ static std::vector<std::unique_ptr<Missile>> LocalMissiles;     /// all local mi
 using MissileTypeMap = std::map<std::string, std::unique_ptr<MissileType>, std::less<>>;
 static MissileTypeMap MissileTypes;
 
-std::vector<std::unique_ptr<BurningBuildingFrame>> BurningBuildingFrames; /// Burning building frames
+std::vector<BurningBuildingFrame> BurningBuildingFrames; /// Burning building frames
 
 extern std::unique_ptr<INumberDesc> Damage;                   /// Damage calculation for missile.
 
@@ -1173,8 +1173,8 @@ int ViewPointDistanceToMissile(const Missile &missile)
 MissileType *MissileBurningBuilding(int percent)
 {
 	for (auto &frame : BurningBuildingFrames) {
-		if (percent > frame->Percent) {
-			return frame->Missile;
+		if (percent > frame.Percent) {
+			return frame.Missile;
 		}
 	}
 	return nullptr;

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1297,6 +1297,19 @@ void CleanMissiles()
 	LocalMissiles.clear();
 }
 
+template <typename Range>
+bool is_PercentSortedDecreasing(Range &range)
+{
+	return ranges::is_sorted(
+		range,
+		[](const auto &lhs, const auto &rhs) { return lhs.Percent > rhs.Percent; });
+}
+
+bool is_BurningBuildingFramesSorted()
+{
+	return is_PercentSortedDecreasing(BurningBuildingFrames);
+}
+
 void FreeBurningBuildingFrames()
 {
 	BurningBuildingFrames.clear();

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1172,7 +1172,8 @@ int ViewPointDistanceToMissile(const Missile &missile)
 */
 MissileType *MissileBurningBuilding(int percent)
 {
-	for (auto &frame : BurningBuildingFrames) {
+	for (int i = BurningBuildingFrames.size() - 1; i >= 0; --i) {
+		const auto &frame = BurningBuildingFrames[i];
 		if (percent >= frame.Percent) {
 			return frame.Missile;
 		}
@@ -1298,24 +1299,24 @@ void CleanMissiles()
 }
 
 template <typename Range>
-bool IsPercentDecreasingValid(const Range &range)
+bool IsPercentIncreasingValid(const Range &range)
 {
 	bool ret = true;
 	if (!range.empty())
 	{
-		ret = range.front().Percent <= 100
-			&& range.back().Percent >= 0;
+		ret = range.front().Percent >= 0
+			&& range.back().Percent <= 100;
 	}
 
 	return ret && ranges::is_sorted(
 		range,
-		std::greater<>{},
+		std::less<>{},
 		[](const auto& e) { return e.Percent; });
 }
 
 bool IsBurningBuildingFramesValid()
 {
-	return IsPercentDecreasingValid(BurningBuildingFrames);
+	return IsPercentIncreasingValid(BurningBuildingFrames);
 }
 
 void FreeBurningBuildingFrames()

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1172,11 +1172,15 @@ int ViewPointDistanceToMissile(const Missile &missile)
 */
 MissileType *MissileBurningBuilding(int percent)
 {
-	for (int i = BurningBuildingFrames.size() - 1; i >= 0; --i) {
-		const auto &frame = BurningBuildingFrames[i];
-		if (percent >= frame.Percent) {
-			return frame.Missile;
-		}
+	const auto it = ranges::upper_bound(
+		std::begin(BurningBuildingFrames),
+		std::end(BurningBuildingFrames),
+		percent,
+		std::less<>{},
+		&BurningBuildingFrame::Percent
+	);
+	if (it != std::begin(BurningBuildingFrames)) {
+		return std::prev(it)->Missile;
 	}
 	return nullptr;
 }

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1173,7 +1173,7 @@ int ViewPointDistanceToMissile(const Missile &missile)
 MissileType *MissileBurningBuilding(int percent)
 {
 	for (auto &frame : BurningBuildingFrames) {
-		if (percent > frame.Percent) {
+		if (percent >= frame.Percent) {
 			return frame.Missile;
 		}
 	}

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1298,11 +1298,12 @@ void CleanMissiles()
 }
 
 template <typename Range>
-bool is_PercentSortedDecreasing(Range &range)
+bool is_PercentSortedDecreasing(const Range &range)
 {
 	return ranges::is_sorted(
 		range,
-		[](const auto &lhs, const auto &rhs) { return lhs.Percent > rhs.Percent; });
+		std::greater(),
+		[](const auto& e) { return e.Percent; });
 }
 
 bool is_BurningBuildingFramesSorted()

--- a/src/missile/missile.cpp
+++ b/src/missile/missile.cpp
@@ -1309,7 +1309,7 @@ bool IsPercentDecreasingValid(const Range &range)
 
 	return ret && ranges::is_sorted(
 		range,
-		std::greater(),
+		std::greater<>{},
 		[](const auto& e) { return e.Percent; });
 }
 

--- a/src/missile/script_missile.cpp
+++ b/src/missile/script_missile.cpp
@@ -359,6 +359,10 @@ static int CclDefineBurningBuilding(lua_State *l)
 			}
 		}
 	}
+	if (!is_BurningBuildingFramesSorted())
+	{
+		LuaError(l, "Percents of BurningBuilding not sorted");
+	}
 	return 0;
 }
 

--- a/src/missile/script_missile.cpp
+++ b/src/missile/script_missile.cpp
@@ -339,11 +339,13 @@ static int CclDefineBurningBuilding(lua_State *l)
 	BurningBuildingFrames.clear();
 
 	const int args = lua_gettop(l);
+	BurningBuildingFrames.resize(args);
 	for (int j = 0; j < args; ++j) {
 		if (!lua_istable(l, j + 1)) {
 			LuaError(l, "incorrect argument");
 		}
-		auto ptr = std::make_unique<BurningBuildingFrame>();
+		const int frameidx = args - 1 - j; // reverse order
+		auto &frame = BurningBuildingFrames[frameidx];
 		const int subargs = lua_rawlen(l, j + 1);
 
 		for (int k = 0; k < subargs; ++k) {
@@ -351,12 +353,11 @@ static int CclDefineBurningBuilding(lua_State *l)
 			++k;
 
 			if (value == "percent") {
-				ptr->Percent = LuaToNumber(l, j + 1, k + 1);
+				frame.Percent = LuaToNumber(l, j + 1, k + 1);
 			} else if (value == "missile") {
-				ptr->Missile = &MissileTypeByIdent(LuaToString(l, j + 1, k + 1));
+				frame.Missile = &MissileTypeByIdent(LuaToString(l, j + 1, k + 1));
 			}
 		}
-		BurningBuildingFrames.insert(BurningBuildingFrames.begin(), std::move(ptr));
 	}
 	return 0;
 }

--- a/src/missile/script_missile.cpp
+++ b/src/missile/script_missile.cpp
@@ -344,8 +344,7 @@ static int CclDefineBurningBuilding(lua_State *l)
 		if (!lua_istable(l, j + 1)) {
 			LuaError(l, "incorrect argument");
 		}
-		const int frameidx = args - 1 - j; // reverse order
-		auto &frame = BurningBuildingFrames[frameidx];
+		auto &frame = BurningBuildingFrames[j];
 		const int subargs = lua_rawlen(l, j + 1);
 
 		for (int k = 0; k < subargs; ++k) {

--- a/src/missile/script_missile.cpp
+++ b/src/missile/script_missile.cpp
@@ -359,9 +359,9 @@ static int CclDefineBurningBuilding(lua_State *l)
 			}
 		}
 	}
-	if (!is_BurningBuildingFramesSorted())
+	if (!IsBurningBuildingFramesValid())
 	{
-		LuaError(l, "Percents of BurningBuilding not sorted");
+		LuaError(l, "Percents of BurningBuilding not valid (percents out of range or not sorted)");
 	}
 	return 0;
 }

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -1,0 +1,172 @@
+//       _________ __                 __
+//      /   _____//  |_____________ _/  |______     ____  __ __  ______
+//      \_____  \\   __\_  __ \__  \\   __\__  \   / ___\|  |  \/  ___/
+//      /        \|  |  |  | \// __ \|  |  / __ \_/ /_/  >  |  /\___ |
+//     /_______  /|__|  |__|  (____  /__| (____  /\___  /|____//____  >
+//             \/                  \/          \//_____/            \/
+//  ______________________                           ______________________
+//                        T H E   W A R   B E G I N S
+//         Stratagus - A free fantasy real time strategy game engine
+//
+/**@name test_missile_fire.cpp - The test file for missile_fire.cpp / missile.cpp. */
+//
+//      (c) Copyright 2024 by Matthias Schwarzott
+//
+//      This program is free software; you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation; only version 2 of the License.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program; if not, write to the Free Software
+//      Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+//      02111-1307, USA.
+//
+
+#include <doctest.h>
+
+#include "stratagus.h"
+#include "missile.h"
+
+namespace {
+	MissileType* M(uintptr_t m)
+	{
+		return reinterpret_cast<MissileType*>(m);
+	}
+
+	void setFrames(const std::vector<std::pair<int, MissileType*>>& frames)
+	{
+		const std::size_t size = frames.size();
+		BurningBuildingFrames.resize(size);
+		for (int i = 0; i < size; ++i) {
+			// reverse order as in CclDefineBurningBuilding
+			BurningBuildingFrames[size - 1 - i].Percent = frames[i].first;
+			BurningBuildingFrames[size - 1 - i].Missile = frames[i].second;
+		}
+	}
+
+} // anonymous namespace
+
+TEST_CASE("missile_fire")
+{
+	BurningBuildingFrames.clear();
+
+	SUBCASE("size=1") {
+		setFrames({
+			{  0, M(10)},
+		});
+
+		CHECK(MissileBurningBuilding(  0) == M(10));
+		CHECK(MissileBurningBuilding(  1) == M(10));
+		CHECK(MissileBurningBuilding(100) == M(10));
+	}
+
+	SUBCASE("large steps") {
+		setFrames({
+			{  0, M(10)},
+			{ 50, M(11)},
+		});
+
+		SUBCASE("normal") {
+			CHECK(MissileBurningBuilding(  0) == M(10));
+			CHECK(MissileBurningBuilding(  1) == M(10));
+			CHECK(MissileBurningBuilding( 49) == M(10));
+			CHECK(MissileBurningBuilding( 50) == M(11));
+			CHECK(MissileBurningBuilding( 51) == M(11));
+			CHECK(MissileBurningBuilding(100) == M(11));
+		}
+
+		SUBCASE("out of bounds") {
+			CHECK(MissileBurningBuilding( -1) == nullptr);
+			CHECK(MissileBurningBuilding(101) == M(11));
+		}
+	}
+
+	SUBCASE("partially dense")
+	{
+		setFrames({
+			{  0, M(10)},
+			{  1, M(11)},
+			{  2, M(12)},
+			{ 65, M(13)},
+			{ 66, M(14)},
+			{ 67, M(15)},
+			{ 99, M(16)},
+			{100, M(17)},
+		});
+
+		CHECK(MissileBurningBuilding(  0) == M(10));
+		CHECK(MissileBurningBuilding(  1) == M(11));
+		CHECK(MissileBurningBuilding(  2) == M(12));
+		CHECK(MissileBurningBuilding(  3) == M(12));
+
+		CHECK(MissileBurningBuilding( 50) == M(12));
+
+		CHECK(MissileBurningBuilding( 64) == M(12));
+		CHECK(MissileBurningBuilding( 65) == M(13));
+		CHECK(MissileBurningBuilding( 66) == M(14));
+		CHECK(MissileBurningBuilding( 67) == M(15));
+		CHECK(MissileBurningBuilding( 68) == M(15));
+
+		CHECK(MissileBurningBuilding( 98) == M(15));
+		CHECK(MissileBurningBuilding( 99) == M(16));
+		CHECK(MissileBurningBuilding(100) == M(17));
+	}
+
+	SUBCASE("repeated values and null")
+	{
+		setFrames({
+			{  0, M(10)},
+			{ 80, nullptr},
+			{ 90, M(10)},
+		});
+
+		CHECK(MissileBurningBuilding( 79) == M(10));
+		CHECK(MissileBurningBuilding( 80) == nullptr);
+		CHECK(MissileBurningBuilding( 89) == nullptr);
+		CHECK(MissileBurningBuilding( 90) == M(10));
+	}
+
+	SUBCASE("first key larger") {
+		setFrames({
+			{ 10, M(1000)},
+		});
+
+		CHECK(MissileBurningBuilding( 9) == nullptr);
+		CHECK(MissileBurningBuilding(10) == M(1000));
+	}
+
+	SUBCASE("duplicate keys")
+	{
+		setFrames({
+			{  0, M(10)},
+			{ 20, M(11)},
+			{ 20, M(12)},
+			{ 60, M(13)},
+		});
+
+		CHECK(MissileBurningBuilding(19) == M(10));
+		CHECK(MissileBurningBuilding(20) == M(12));
+		CHECK(MissileBurningBuilding(21) == M(12));
+	}
+
+	SUBCASE("wrong key order") {
+		setFrames({
+			{ 75, M(12)},
+			{ 50, M(11)},
+			{  0, M(10)},
+		});
+
+		CHECK(MissileBurningBuilding(  0) == M(10));
+		CHECK(MissileBurningBuilding( 20) == M(10));
+		CHECK(MissileBurningBuilding( 50) == M(10));
+		CHECK(MissileBurningBuilding( 60) == M(10));
+		CHECK(MissileBurningBuilding( 75) == M(10));
+		CHECK(MissileBurningBuilding( 90) == M(10));
+	}
+
+}

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -55,6 +55,12 @@ TEST_CASE("missile_fire")
 {
 	BurningBuildingFrames.clear();
 
+	SUBCASE("size=0") {
+		setFrames({});
+
+		CHECK(MissileBurningBuilding(  0) == nullptr);
+	}
+
 	SUBCASE("size=1") {
 		setFrames({
 			{  0, M(10)},

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -68,7 +68,7 @@ TEST_CASE("missile_fire")
 
 	SUBCASE("size=0") {
 		setFrames({});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		CHECK(MissileBurningBuilding(  0) == nullptr);
 	}
@@ -77,7 +77,7 @@ TEST_CASE("missile_fire")
 		setFrames({
 			{  0, m0},
 		});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		CHECK(MissileBurningBuilding(  0) == m0);
 		CHECK(MissileBurningBuilding(  1) == m0);
@@ -89,7 +89,7 @@ TEST_CASE("missile_fire")
 			{  0, m0},
 			{ 50, m1},
 		});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		SUBCASE("normal") {
 			CHECK(MissileBurningBuilding(  0) == m0);
@@ -118,7 +118,7 @@ TEST_CASE("missile_fire")
 			{ 99, m6},
 			{100, m7},
 		});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		CHECK(MissileBurningBuilding(  0) == m0);
 		CHECK(MissileBurningBuilding(  1) == m1);
@@ -145,7 +145,7 @@ TEST_CASE("missile_fire")
 			{ 80, nullptr},
 			{ 90, m8},
 		});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		CHECK(MissileBurningBuilding( 79) == m8);
 		CHECK(MissileBurningBuilding( 80) == nullptr);
@@ -157,7 +157,7 @@ TEST_CASE("missile_fire")
 		setFrames({
 			{ 10, m5},
 		});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		CHECK(MissileBurningBuilding( 9) == nullptr);
 		CHECK(MissileBurningBuilding(10) == m5);
@@ -171,7 +171,7 @@ TEST_CASE("missile_fire")
 			{ 20, m2},
 			{ 60, m3},
 		});
-		CHECK(is_BurningBuildingFramesSorted());
+		CHECK(IsBurningBuildingFramesValid());
 
 		CHECK(MissileBurningBuilding(19) == m0);
 		CHECK(MissileBurningBuilding(20) == m2);
@@ -185,7 +185,25 @@ TEST_CASE("missile_fire")
 			{  0, m7},
 		});
 
-		CHECK_FALSE(is_BurningBuildingFramesSorted());
+		CHECK_FALSE(IsBurningBuildingFramesValid());
+	}
+
+	SUBCASE("too small key value") {
+		setFrames({
+			{ -1, m7},
+			{100, m8},
+		});
+
+		CHECK_FALSE(IsBurningBuildingFramesValid());
+	}
+
+	SUBCASE("too large key value") {
+		setFrames({
+			{  0, m7},
+			{101, m8},
+		});
+
+		CHECK_FALSE(IsBurningBuildingFramesValid());
 	}
 
 	BurningBuildingFrames.clear();

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -57,6 +57,7 @@ TEST_CASE("missile_fire")
 
 	SUBCASE("size=0") {
 		setFrames({});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding(  0) == nullptr);
 	}
@@ -65,6 +66,7 @@ TEST_CASE("missile_fire")
 		setFrames({
 			{  0, M(10)},
 		});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding(  0) == M(10));
 		CHECK(MissileBurningBuilding(  1) == M(10));
@@ -76,6 +78,7 @@ TEST_CASE("missile_fire")
 			{  0, M(10)},
 			{ 50, M(11)},
 		});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		SUBCASE("normal") {
 			CHECK(MissileBurningBuilding(  0) == M(10));
@@ -104,6 +107,7 @@ TEST_CASE("missile_fire")
 			{ 99, M(16)},
 			{100, M(17)},
 		});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding(  0) == M(10));
 		CHECK(MissileBurningBuilding(  1) == M(11));
@@ -130,6 +134,7 @@ TEST_CASE("missile_fire")
 			{ 80, nullptr},
 			{ 90, M(10)},
 		});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding( 79) == M(10));
 		CHECK(MissileBurningBuilding( 80) == nullptr);
@@ -141,6 +146,7 @@ TEST_CASE("missile_fire")
 		setFrames({
 			{ 10, M(1000)},
 		});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding( 9) == nullptr);
 		CHECK(MissileBurningBuilding(10) == M(1000));
@@ -154,6 +160,7 @@ TEST_CASE("missile_fire")
 			{ 20, M(12)},
 			{ 60, M(13)},
 		});
+		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding(19) == M(10));
 		CHECK(MissileBurningBuilding(20) == M(12));
@@ -162,17 +169,11 @@ TEST_CASE("missile_fire")
 
 	SUBCASE("wrong key order") {
 		setFrames({
-			{ 75, M(12)},
 			{ 50, M(11)},
 			{  0, M(10)},
 		});
 
-		CHECK(MissileBurningBuilding(  0) == M(10));
-		CHECK(MissileBurningBuilding( 20) == M(10));
-		CHECK(MissileBurningBuilding( 50) == M(10));
-		CHECK(MissileBurningBuilding( 60) == M(10));
-		CHECK(MissileBurningBuilding( 75) == M(10));
-		CHECK(MissileBurningBuilding( 90) == M(10));
+		CHECK_FALSE(is_BurningBuildingFramesSorted());
 	}
 
 	BurningBuildingFrames.clear();

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -169,4 +169,5 @@ TEST_CASE("missile_fire")
 		CHECK(MissileBurningBuilding( 90) == M(10));
 	}
 
+	BurningBuildingFrames.clear();
 }

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -33,9 +33,9 @@
 #include "missile.h"
 
 namespace {
-	MissileType* M(uintptr_t m)
+	MissileType* dummyMissile(uintptr_t m)
 	{
-		return reinterpret_cast<MissileType*>(m);
+		return reinterpret_cast<MissileType*>(0x10000 + m);
 	}
 
 	void setFrames(const std::vector<std::pair<int, MissileType*>>& frames)
@@ -53,6 +53,17 @@ namespace {
 
 TEST_CASE("missile_fire")
 {
+	MissileType *m0 = dummyMissile(0);
+	MissileType *m1 = dummyMissile(1);
+	MissileType *m2 = dummyMissile(2);
+	MissileType *m3 = dummyMissile(3);
+	MissileType *m4 = dummyMissile(4);
+	MissileType *m5 = dummyMissile(5);
+	MissileType *m6 = dummyMissile(6);
+	MissileType *m7 = dummyMissile(7);
+	MissileType *m8 = dummyMissile(8);
+	MissileType *m9 = dummyMissile(9);
+
 	BurningBuildingFrames.clear();
 
 	SUBCASE("size=0") {
@@ -64,113 +75,114 @@ TEST_CASE("missile_fire")
 
 	SUBCASE("size=1") {
 		setFrames({
-			{  0, M(10)},
+			{  0, m0},
 		});
 		CHECK(is_BurningBuildingFramesSorted());
 
-		CHECK(MissileBurningBuilding(  0) == M(10));
-		CHECK(MissileBurningBuilding(  1) == M(10));
-		CHECK(MissileBurningBuilding(100) == M(10));
+		CHECK(MissileBurningBuilding(  0) == m0);
+		CHECK(MissileBurningBuilding(  1) == m0);
+		CHECK(MissileBurningBuilding(100) == m0);
 	}
 
 	SUBCASE("large steps") {
 		setFrames({
-			{  0, M(10)},
-			{ 50, M(11)},
+			{  0, m0},
+			{ 50, m1},
 		});
 		CHECK(is_BurningBuildingFramesSorted());
 
 		SUBCASE("normal") {
-			CHECK(MissileBurningBuilding(  0) == M(10));
-			CHECK(MissileBurningBuilding(  1) == M(10));
-			CHECK(MissileBurningBuilding( 49) == M(10));
-			CHECK(MissileBurningBuilding( 50) == M(11));
-			CHECK(MissileBurningBuilding( 51) == M(11));
-			CHECK(MissileBurningBuilding(100) == M(11));
+			CHECK(MissileBurningBuilding(  0) == m0);
+			CHECK(MissileBurningBuilding(  1) == m0);
+			CHECK(MissileBurningBuilding( 49) == m0);
+			CHECK(MissileBurningBuilding( 50) == m1);
+			CHECK(MissileBurningBuilding( 51) == m1);
+			CHECK(MissileBurningBuilding(100) == m1);
 		}
 
 		SUBCASE("out of bounds") {
 			CHECK(MissileBurningBuilding( -1) == nullptr);
-			CHECK(MissileBurningBuilding(101) == M(11));
+			CHECK(MissileBurningBuilding(101) == m1);
 		}
 	}
 
 	SUBCASE("partially dense")
 	{
 		setFrames({
-			{  0, M(10)},
-			{  1, M(11)},
-			{  2, M(12)},
-			{ 65, M(13)},
-			{ 66, M(14)},
-			{ 67, M(15)},
-			{ 99, M(16)},
-			{100, M(17)},
+			{  0, m0},
+			{  1, m1},
+			{  2, m2},
+			{ 65, m3},
+			{ 66, m4},
+			{ 67, m5},
+			{ 99, m6},
+			{100, m7},
 		});
 		CHECK(is_BurningBuildingFramesSorted());
 
-		CHECK(MissileBurningBuilding(  0) == M(10));
-		CHECK(MissileBurningBuilding(  1) == M(11));
-		CHECK(MissileBurningBuilding(  2) == M(12));
-		CHECK(MissileBurningBuilding(  3) == M(12));
+		CHECK(MissileBurningBuilding(  0) == m0);
+		CHECK(MissileBurningBuilding(  1) == m1);
+		CHECK(MissileBurningBuilding(  2) == m2);
+		CHECK(MissileBurningBuilding(  3) == m2);
 
-		CHECK(MissileBurningBuilding( 50) == M(12));
+		CHECK(MissileBurningBuilding( 50) == m2);
 
-		CHECK(MissileBurningBuilding( 64) == M(12));
-		CHECK(MissileBurningBuilding( 65) == M(13));
-		CHECK(MissileBurningBuilding( 66) == M(14));
-		CHECK(MissileBurningBuilding( 67) == M(15));
-		CHECK(MissileBurningBuilding( 68) == M(15));
+		CHECK(MissileBurningBuilding( 64) == m2);
+		CHECK(MissileBurningBuilding( 65) == m3);
+		CHECK(MissileBurningBuilding( 66) == m4);
+		CHECK(MissileBurningBuilding( 67) == m5);
+		CHECK(MissileBurningBuilding( 68) == m5);
 
-		CHECK(MissileBurningBuilding( 98) == M(15));
-		CHECK(MissileBurningBuilding( 99) == M(16));
-		CHECK(MissileBurningBuilding(100) == M(17));
+		CHECK(MissileBurningBuilding( 98) == m5);
+		CHECK(MissileBurningBuilding( 99) == m6);
+		CHECK(MissileBurningBuilding(100) == m7);
 	}
 
 	SUBCASE("repeated values and null")
 	{
 		setFrames({
-			{  0, M(10)},
+			{  0, m8},
 			{ 80, nullptr},
-			{ 90, M(10)},
+			{ 90, m8},
 		});
 		CHECK(is_BurningBuildingFramesSorted());
 
-		CHECK(MissileBurningBuilding( 79) == M(10));
+		CHECK(MissileBurningBuilding( 79) == m8);
 		CHECK(MissileBurningBuilding( 80) == nullptr);
 		CHECK(MissileBurningBuilding( 89) == nullptr);
-		CHECK(MissileBurningBuilding( 90) == M(10));
+		CHECK(MissileBurningBuilding( 90) == m8);
 	}
 
 	SUBCASE("first key larger") {
 		setFrames({
-			{ 10, M(1000)},
+			{ 10, m5},
 		});
 		CHECK(is_BurningBuildingFramesSorted());
 
 		CHECK(MissileBurningBuilding( 9) == nullptr);
-		CHECK(MissileBurningBuilding(10) == M(1000));
+		CHECK(MissileBurningBuilding(10) == m5);
 	}
 
 	SUBCASE("duplicate keys")
 	{
 		setFrames({
-			{  0, M(10)},
-			{ 20, M(11)},
-			{ 20, M(12)},
-			{ 60, M(13)},
+			{  0, m0},
+			{ 20, m1},
+			{ 20, m2},
+			{ 60, m3},
 		});
 		CHECK(is_BurningBuildingFramesSorted());
 
-		CHECK(MissileBurningBuilding(19) == M(10));
-		CHECK(MissileBurningBuilding(20) == M(12));
-		CHECK(MissileBurningBuilding(21) == M(12));
+		CHECK(MissileBurningBuilding(19) == m0);
+		CHECK(MissileBurningBuilding(20) == m2);
+		CHECK(MissileBurningBuilding(21) == m2);
 	}
 
 	SUBCASE("wrong key order") {
 		setFrames({
-			{ 50, M(11)},
-			{  0, M(10)},
+			{ 75, m9},
+			{ 50, m8},
+			{  0, m7},
 		});
 
 		CHECK_FALSE(is_BurningBuildingFramesSorted());

--- a/tests/stratagus/test_missile_fire.cpp
+++ b/tests/stratagus/test_missile_fire.cpp
@@ -43,9 +43,8 @@ namespace {
 		const std::size_t size = frames.size();
 		BurningBuildingFrames.resize(size);
 		for (int i = 0; i < size; ++i) {
-			// reverse order as in CclDefineBurningBuilding
-			BurningBuildingFrames[size - 1 - i].Percent = frames[i].first;
-			BurningBuildingFrames[size - 1 - i].Missile = frames[i].second;
+			BurningBuildingFrames[i].Percent = frames[i].first;
+			BurningBuildingFrames[i].Missile = frames[i].second;
 		}
 	}
 


### PR DESCRIPTION
Burning animation disappears before building is completely destroyed.
Fix and add unittest.
Simplify storage a bit.
Comment: Percent logic is similar to construction. Code could be combined.

State before:
Burning at 6/400=1.5%:
![image](https://github.com/Wargus/stratagus/assets/99672/4a282873-7724-4ffd-9ee5-34e7bb75547b)

No longer burning at 2/400=0.5%:
![image](https://github.com/Wargus/stratagus/assets/99672/7176dd63-2124-4dcf-9cd2-8ad17bc0de8a)
