### PR TITLE
Replace C-header `<stdint.h>` by C++-header `<cstdint>`.

### DIFF
--- a/src/editor/editloop.cpp
+++ b/src/editor/editloop.cpp
@@ -34,8 +34,8 @@
 --  Includes
 ----------------------------------------------------------------------------*/
 
+#include <cstdint>
 #include <deque>
-#include <stdint.h>
 
 #include "stratagus.h"
 

--- a/src/include/net_message.h
+++ b/src/include/net_message.h
@@ -31,7 +31,7 @@
 
 //@{
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include "settings.h"

--- a/src/include/settings.h
+++ b/src/include/settings.h
@@ -38,7 +38,7 @@
 //@{
 
 #include <bitset>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <functional>


### PR DESCRIPTION
That should ensure that `uintXX_t` is (also) in namespace `std`.