### PR TITLE
add missing <string.h>; fixes #688

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -106,6 +106,8 @@
 --  Includes
 ----------------------------------------------------------------------------*/
 
+#include <string>
+
 #include "sdl2_helper.h"
 #include "vec2i.h"
 


### PR DESCRIPTION
add missing include statement into `src/include/cursor.h`:

```c
#include <string>  // new line
```