### PR TITLE
Display title screen in 4:3

### DIFF
--- a/src/include/video.h
+++ b/src/include/video.h
@@ -328,6 +328,7 @@ public:
 
 	void ClearScreen();
 	bool ResizeScreen(int width, int height);
+	void CalculateAspectRatioCorrectDimensions();
 
 	void DrawPixelClip(Uint32 color, int x, int y);
 	void DrawTransPixelClip(Uint32 color, int x, int y, unsigned char alpha);
@@ -393,6 +394,8 @@ public:
 
 	int Width = 0;
 	int Height = 0;
+	int FourThreeWidth = 0;
+	int FourThreeHeight = 0;
 	int WindowWidth = 0;
 	int WindowHeight = 0;
 	double VerticalPixelSize = 1.;

--- a/src/stratagus/stratagus.cpp
+++ b/src/stratagus/stratagus.cpp
@@ -613,6 +613,7 @@ void ParseCommandLine(int argc, char **argv, Parameters &parameters)
 					Usage();
 					exit(-1);
 				}
+				Video.CalculateAspectRatioCorrectDimensions();
 				continue;
 			}
 			case 'W':

--- a/src/stratagus/title.cpp
+++ b/src/stratagus/title.cpp
@@ -49,8 +49,8 @@ void TitleScreen::ShowLabels()
 			continue;
 		}
 		// offsets are for 640x480, scale up to actual resolution
-		const int x = titleScreenlabel->Xofs * Video.Width / 640;
-		const int y = titleScreenlabel->Yofs * Video.Height / 480;
+		const int x = titleScreenlabel->Xofs * Video.FourThreeWidth / 640 + (Video.Width - Video.FourThreeWidth)/2;
+		const int y = titleScreenlabel->Yofs * Video.FourThreeHeight / 480 + (Video.Height - Video.FourThreeHeight)/2;
 		CLabel label(*titleScreenlabel->Font);
 
 		if (titleScreenlabel->Flags & TitleFlagCenter) {
@@ -86,13 +86,13 @@ void TitleScreen::ShowTitleImage()
 	auto g = CGraphic::New(this->File.string());
 	g->Load();
 	if (this->StretchImage) {
-		g->Resize(Video.Width, Video.Height);
+		g->Resize(Video.FourThreeWidth, Video.FourThreeHeight);
 	}
 
 	int timeout = this->Timeout ? this->Timeout * CYCLES_PER_SECOND : -1;
 
 	while (timeout-- && WaitNoEvent) {
-		g->DrawClip((Video.Width - g->Width) / 2, (Video.Height - g->Height) / 2);
+		g->DrawClip((Video.FourThreeWidth - g->Width) / 2 + (Video.Width - Video.FourThreeWidth) / 2, (Video.FourThreeHeight - g->Height) / 2 + (Video.Height - Video.FourThreeHeight) / 2);
 		this->ShowLabels();
 
 		Invalidate();

--- a/src/tolua/video.pkg
+++ b/src/tolua/video.pkg
@@ -11,6 +11,8 @@ class CVideo
 public:
 	int Width;
 	int Height;
+	int FourThreeWidth;
+	int FourThreeHeight;
 	int Depth;
 	bool FullScreen;
 	bool ResizeScreen(int width, int height);

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -273,6 +273,7 @@ bool CVideo::ResizeScreen(int w, int h)
 	}
 	Width = w;
 	Height = h;
+	CalculateAspectRatioCorrectDimensions();
 
 	SDL_RenderSetLogicalSize(TheRenderer, w, h * VerticalPixelSize);
 
@@ -307,6 +308,28 @@ bool CVideo::ResizeScreen(int w, int h)
 	SetClipping(0, 0, w - 1, h - 1);
 
 	return true;
+}
+
+/**
+**  Calculate dimensions for the background/title to be displayed at the original 4:3 aspect ratio.
+**
+*/
+void CVideo::CalculateAspectRatioCorrectDimensions() {
+	float ratio = 1.0*Width/Height;
+	float origRatio = 640.0/480.0;
+	if (ratio > origRatio) {
+		FourThreeHeight = Height;
+		FourThreeWidth = (int)(Width / ratio * origRatio);
+	}
+	else if (ratio < origRatio) {
+		// tall screen?
+		FourThreeWidth = Width;
+		FourThreeHeight = (int)(Height / origRatio * ratio);
+	}
+	else {
+		FourThreeWidth = Width;
+		FourThreeHeight = Height;
+	}
 }
 
 /**


### PR DESCRIPTION
displays title screens at the original 4:3 aspect ratio, preserving the art (preventing it from being stretched)

Also exports versions of Video.Width and Height adjusted for 4:3 so games (ie Wargus) can also display menu backgrounds at the original aspect ratio, again preserving the original art