### PR TITLE
Allow to define stretch mode to title screen:

### DIFF
--- a/src/include/title.h
+++ b/src/include/title.h
@@ -70,7 +70,6 @@ public:
 	std::string Music;
 	bool StretchImage = true;
 	int Timeout = 0;
-	int Iterations = 0;
 	int Editor = 0;
 	std::vector<std::unique_ptr<TitleScreenLabel>> Labels;
 };

--- a/src/include/title.h
+++ b/src/include/title.h
@@ -55,6 +55,15 @@ public:
 	int Flags = 0;
 };
 
+enum class EStretchMode
+{
+	None,
+	KeepRatio,
+	Stretch
+};
+
+std::optional<EStretchMode> StretchModeFromString(std::string_view);
+
 class TitleScreen
 {
 public:
@@ -64,11 +73,11 @@ public:
 	void ShowTitleImage();
 
 private:
-	void ShowLabels();
+	void ShowLabels() const;
 public:
 	fs::path File;
 	std::string Music;
-	bool StretchImage = true;
+	EStretchMode StretchMode = EStretchMode::Stretch;
 	int Timeout = 0;
 	int Editor = 0;
 	std::vector<std::unique_ptr<TitleScreenLabel>> Labels;

--- a/src/ui/script_ui.cpp
+++ b/src/ui/script_ui.cpp
@@ -372,7 +372,6 @@ static int CclSetTitleScreens(lua_State *l)
 			LuaError(l, "incorrect argument");
 		}
 		TitleScreens[j] = std::make_unique<TitleScreen>();
-		TitleScreens[j]->Iterations = 1;
 		lua_pushnil(l);
 		while (lua_next(l, j + 1)) {
 			const std::string_view value = LuaToString(l, -2);
@@ -382,8 +381,6 @@ static int CclSetTitleScreens(lua_State *l)
 				TitleScreens[j]->Music = LuaToString(l, -1);
 			} else if (value == "Timeout") {
 				TitleScreens[j]->Timeout = LuaToNumber(l, -1);
-			} else if (value == "Iterations") {
-				TitleScreens[j]->Iterations = LuaToNumber(l, -1);
 			} else if (value == "Editor") {
 				TitleScreens[j]->Editor = LuaToNumber(l, -1);
 			} else if (value == "Labels") {

--- a/src/ui/script_ui.cpp
+++ b/src/ui/script_ui.cpp
@@ -377,6 +377,13 @@ static int CclSetTitleScreens(lua_State *l)
 			const std::string_view value = LuaToString(l, -2);
 			if (value == "Image") {
 				TitleScreens[j]->File = LuaToString(l, -1);
+			} else if (value == "StretchMode") {
+				const std::string_view value = LuaToString(l, -1);
+				if (auto stretchMode = StretchModeFromString(value)) {
+					TitleScreens[j]->StretchMode = *stretchMode;
+				} else {
+					LuaError(l, "Unknown StretchMode %s", value.data());
+				}
 			} else if (value == "Music") {
 				TitleScreens[j]->Music = LuaToString(l, -1);
 			} else if (value == "Timeout") {


### PR DESCRIPTION
```
SetTitleScreens(
  {Image = "ui/title.png", StretchMode = "none"}, -- Keep original image size
  {Image = "ui/title.png", StretchMode = "keep-ratio"}, -- resize to touch border, and keep original size ratio
  {Image = "ui/title.png", StretchMode = "stretch"} -- (default) resize to the full windows
)
```