### PR TITLE
[fix] Fix regression…

### DIFF
--- a/src/unit/build.cpp
+++ b/src/unit/build.cpp
@@ -464,7 +464,7 @@ std::optional<CUnit *> CanBuildHere(const CUnit *unit, const CUnitType &type, co
 
 	// Check special rules for AI players
 	if (unit && unit->Player->AiEnabled) {
-		if (ranges::none_of(type.AiBuildingRules, [&](const auto &rule) {
+		if (!ranges::any_of(type.AiBuildingRules, [&](const auto &rule) {
 				CUnit *ontoptarget = nullptr;
 				return rule->Check(unit, type, pos, ontoptarget);
 			})) {


### PR DESCRIPTION
 introduced by commit 936b1dc09c7360072b21544cc599756bba0fa906 (Fix regression in editor to place units.)

#closes https://github.com/Wargus/wargus/issues/449
Thanks to MamiyaOtaru for investigation and fix.
Other `none_of` should be ok.