### PR TITLE
Revert "[cleanup] Use `std::unique_ptr` for `unitSlots`."

### DIFF
--- a/src/include/unit_manager.h
+++ b/src/include/unit_manager.h
@@ -50,8 +50,7 @@ struct lua_State;
 class CUnitManager
 {
 public:
-	CUnitManager();
-	~CUnitManager();
+	CUnitManager() = default;
 	void Init();
 
 	CUnit *AllocUnit();
@@ -73,7 +72,7 @@ public:
 
 private:
 	std::vector<CUnit *> units;
-	std::vector<std::unique_ptr<CUnit>> unitSlots;
+	std::vector<CUnit *> unitSlots;
 	std::list<CUnit *> releasedUnits;
 	CUnit *lastCreated = nullptr;
 };


### PR DESCRIPTION
This reverts commit c8ff12112548e95e7eca85d69a1a385085b33e7f.

Crash with typo with `unit->UnitManagerData.slot = unitSlots.size() - 1;`.
but also destruction all unit cause a crash with destruction order, so revert back to memory leak.