### PR TITLE
Added tool to set a brush tile with picked one from the map.

### DIFF
--- a/src/editor/edmap.cpp
+++ b/src/editor/edmap.cpp
@@ -86,6 +86,34 @@ std::optional<tile_index> CTileIconsSet::getSelectedTile() const
 	return std::nullopt;
 }
 
+bool CTileIconsSet::selectByTile(tile_index tileIdx)
+{
+	const auto prevSelected = selected;
+
+	auto tryToSelect = [this](tile_index idx) {
+		if (const auto it = ranges::find(icons, idx); it != icons.end()) {
+			select(std::distance(icons.begin(), it));
+			return true;
+		}
+		return false;
+	};
+	if (!tryToSelect(tileIdx)) {
+		tryToSelect(Map.Tileset.getFirstOfItsKindTile(tileIdx));
+	}
+	if (isSelected() && selected != prevSelected) {
+		if (displayedNum == 0) {
+			displayFrom(0);
+			ErrorPrint("Trying to set first displayed tile icon, "
+						"but the number of possible displayed icons is 0.\n");
+		} else {
+			const uint16_t k = selected / displayedNum;
+			displayFrom(displayedNum * k);
+		}
+		return true;
+	}
+	return false;
+}
+
 void CTileIconsSet::rebuild(bool manualMode /* = false */, bool firstOfKindOnly /* = true */)
 {
 	resetSelected();

--- a/src/include/editor.h
+++ b/src/include/editor.h
@@ -95,6 +95,8 @@ public:
 	}
 	void resetSelected() { selected = -1; }
 
+	bool selectByTile(tile_index tileIdx);
+
 	size_t numberOf() const { return icons.size(); }
 
 	void rebuild(bool manualMode = false, bool firstOfKindOnly = true);

--- a/src/include/tileset.h
+++ b/src/include/tileset.h
@@ -213,6 +213,7 @@ public:
 	std::vector<tile_index> queryAllTiles() const;
 	std::vector<tile_index> querySolidTiles() const;
 	std::vector<tile_index> queryFirstOfItsKindTiles() const;
+	tile_index getFirstOfItsKindTile(tile_index tileIndex) const;
 
 	uint32_t getQuadFromTile(tile_index tileIndex) const;
 	int getTileBySurrounding(tile_flags type,

--- a/src/map/tileset.cpp
+++ b/src/map/tileset.cpp
@@ -780,6 +780,24 @@ std::vector<tile_index> CTileset::queryFirstOfItsKindTiles() const
 	return result;
 }
 
+tile_index CTileset::getFirstOfItsKindTile(tile_index tileIndex) const
+{
+	if (getGraphicTileFor(tileIndex) == 0) {
+		ErrorPrint("Requested first tile in the subslot for empty tile: %d\n", tileIndex);
+		return tileIndex;
+	}
+	tile_index result = tileIndex;
+	constexpr tile_index subSlotLen = 0xF;
+	while ((result & subSlotLen) != 0) {
+		if (getGraphicTileFor(result) == 0) {
+			result += 1;
+			break;
+		}
+		result--;
+	}
+	return result;
+}
+
 unsigned CTileset::getWallDirection(tile_index tileIndex, bool human) const
 {
 	int i;


### PR DESCRIPTION
To set current single tiled type brush with a tile not from tile icons palette, but from any map field under cursor you should:
1. reset selected tile (right click)
2. ctrl+left click on the any tile within map grid.
