### PR TITLE
[CI] workaround for CMake4.O

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build stratagus
       run: |
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_VENDORED_LUA=ON -DBUILD_VENDORED_SDL=OFF -DBUILD_VENDORED_MEDIA_LIBS=OFF -DBUILD_TESTING=1
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_VENDORED_LUA=ON -DBUILD_VENDORED_SDL=OFF -DBUILD_VENDORED_MEDIA_LIBS=OFF -DBUILD_TESTING=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         cmake --build . --config Release
 
     - name: run tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,6 @@ on:
       - '!**.md'
       - '!.vscode/**'
       - '!doc/**'
-      - '!doc/**'
 
   pull_request:
     paths:
@@ -21,7 +20,6 @@ on:
       - '.github/workflows/ubuntu.yml'
       - '!**.md'
       - '!.vscode/**'
-      - '!doc/**'
       - '!doc/**'
 
 jobs:
@@ -43,7 +41,7 @@ jobs:
     - name: build stratagus
       run: |
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_VENDORED_LUA=ON -DBUILD_VENDORED_SDL=ON -DBUILD_VENDORED_MEDIA_LIBS=ON -DBUILD_TESTING=1
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_VENDORED_LUA=ON -DBUILD_VENDORED_SDL=ON -DBUILD_VENDORED_MEDIA_LIBS=ON -DBUILD_TESTING=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         cmake --build . --config Release
         
     - name: run tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,6 @@ on:
       - '!**.md'
       - '!.vscode/**'
       - '!doc/**'
-      - '!doc/**'
 
   pull_request:
     paths:
@@ -21,7 +20,6 @@ on:
       - '.github/workflows/windows.yml'
       - '!**.md'
       - '!.vscode/**'
-      - '!doc/**'
       - '!doc/**'
 
 jobs:
@@ -40,7 +38,7 @@ jobs:
     - name: build stratagus
       run: | # -DENABLE_NSIS=ON
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_VENDORED_LUA=ON -DBUILD_VENDORED_SDL=ON -DBUILD_VENDORED_MEDIA_LIBS=ON -DENABLE_STDIO_REDIRECT=ON -DBUILD_TESTING=1
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_VENDORED_LUA=ON -DBUILD_VENDORED_SDL=ON -DBUILD_VENDORED_MEDIA_LIBS=ON -DENABLE_STDIO_REDIRECT=ON -DBUILD_TESTING=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         cmake --build . --config Release
         
     - name: run tests


### PR DESCRIPTION
 which no longer supports `cmake_minimum_required` < 3.5 (3rd party)