### PR TITLE
[fix] Change type of `AiForceManager::script`

### DIFF
--- a/src/ai/ai_local.h
+++ b/src/ai/ai_local.h
@@ -239,7 +239,7 @@ public:
 
 private:
 	std::vector<AiForce> forces;
-	char script[AI_MAX_FORCES];
+	unsigned int script[AI_MAX_FORCES];
 };
 
 /**


### PR DESCRIPTION
comparison with `-1` is now correct in `getScriptForce` (even when `char` is `unsigned`).

fixes #739