### PR TITLE
Fix nullptr crash when moving camera after loading game

### DIFF
--- a/src/unit/unit_draw.cpp
+++ b/src/unit/unit_draw.cpp
@@ -957,7 +957,7 @@ void CUnit::Draw(const CViewport &vp) const
 		type = this->Seen.Type;
 		constructed = this->Seen.Constructed;
 		state = this->Seen.State;
-		cframe = this->Seen.CFrame != -1 ? &type->Construction->Frames[this->Seen.CFrame] : nullptr;
+		cframe = (this->Seen.CFrame != -1 && type->Construction) ? &type->Construction->Frames[this->Seen.CFrame] : nullptr;
 	}
 
 #ifdef DYNAMIC_LOAD


### PR DESCRIPTION
Hi there :)

I'm new to Stratagus and just found out about it via Wargus. First of all awesome work, thank you very much!

I was playing the W2 campaign and after loading a savegame I moved the camera to my base which lead to a crash. I noticed that this is reproducible so I run with GDB attached and looked at the backtrace: `type->Construction` is nullptr. Adding this check fixes the crash and I can continue playing just fine. I have no idea what this code does though :D

I can provide you with the savegame if you want.