### PR TITLE
Restore game cycle when loading a game. Fixes Wargus/wargus#410

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -142,7 +142,7 @@ void StartMap(const std::string &filename, bool clean)
 	SetMessage("%s", _("Do it! Do it now!"));
 
 	//  Play the game.
-	GameMainLoop();
+	GameMainLoop(clean);
 
 	//  Clear screen
 	Video.ClearScreen();

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -590,6 +590,7 @@ static void LoadReplay(const fs::path &name)
 {
 	CleanReplayLog();
 	ReplayGameType = EReplayType::SinglePlayer;
+	GameCycle = 0;
 	LuaLoadFile(name);
 
 	NextLogCycle = ~0UL;

--- a/src/include/stratagus.h
+++ b/src/include/stratagus.h
@@ -204,7 +204,7 @@ extern void Exit(int err);                  /// Exit
 [[noreturn]] void ExitFatal(int err); /// Exit with fatal error
 
 extern void UpdateDisplay();            /// Game display update
-extern void GameMainLoop();             /// Game main loop
+extern void GameMainLoop(bool clean);            /// Game main loop
 extern int stratagusMain(int argc, char **argv); /// main entry
 
 //@}

--- a/src/stratagus/mainloop.cpp
+++ b/src/stratagus/mainloop.cpp
@@ -387,7 +387,7 @@ static void SingleGameLoop()
 **  Display update.
 **  Input/Network/Sound.
 */
-void GameMainLoop()
+void GameMainLoop(bool clean)
 {
 	const EventCallback *old_callbacks;
 
@@ -398,7 +398,9 @@ void GameMainLoop()
 
 	SetVideoSync();
 	GameCursor = UI.Point.Cursor;
-	GameCycle = 0;
+	if (clean) {
+		GameCycle = 0;
+	}
 	GameRunning = true;
 
 	CParticleManager::init();


### PR DESCRIPTION
Only reset GameCycle when starting a clean game or for a replay, not when loading