### PR TITLE
Keep unit heading randomness simulation-only

### DIFF
--- a/src/unit/unit.cpp
+++ b/src/unit/unit.cpp
@@ -598,7 +598,7 @@ void CUnit::Init(const CUnitType &type)
 	// Set a heading for the unit if it Handles Directions
 	// Don't set a building heading, as only 1 construction direction
 	//   is allowed.
-	if (type.NumDirections > 1 && type.BoolFlag[NORANDOMPLACING_INDEX].value == false && type.Sprite && !type.Building) {
+	if (type.NumDirections > 1 && type.BoolFlag[NORANDOMPLACING_INDEX].value == false && !type.Building) {
 		Direction = (SyncRand() >> 8) & 0xFF; // random heading
 		UnitUpdateHeading(*this);
 	}


### PR DESCRIPTION
This fixes a desync that happens quite often whenever players pick different races.